### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A [ModelContextProtocol](https://modelcontextprotocol.io) server that gives your AI coding tool or agent access to documentation for APIs, services, libraries etc. It's your one-stop-shop to keep your agent up-to-date on documentation in a fast and token-efficient way.
 
+<a href="https://glama.ai/mcp/servers/@ref-tools/ref-tools-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ref-tools/ref-tools-mcp/badge" alt="Ref MCP server" />
+</a>
+
 For more see info [ref.tools](https://ref.tools)
 
 ## Setup


### PR DESCRIPTION
This PR adds a badge for the [Ref](https://glama.ai/mcp/servers/@ref-tools/ref-tools-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ref-tools/ref-tools-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ref-tools/ref-tools-mcp/badge" alt="Ref MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.