### PR TITLE
Remove overview line from markdown response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ref-tools-mcp",
-  "version": "0.16.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ref-tools-mcp",
-      "version": "0.16.0",
+      "version": "2.0.0",
       "dependencies": {
         "@modelcontextprotocol/inspector": "^0.10.2",
         "@modelcontextprotocol/sdk": "^1.0.3",
@@ -21,7 +21,7 @@
         "esbuild": "^0.24.0",
         "prettier": "^3.4.2",
         "tsx": "^4.19.4",
-        "typescript": "^5.3.3"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "esbuild": "^0.24.0",
     "prettier": "^3.4.2",
     "tsx": "^4.19.4",
-    "typescript": "^5.3.3"
+    "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
Extract `overview:` line from private repo markdown content and reformat it into the document metadata.