### PR TITLE
Implement in-memory GraphDB with Cypher support

### DIFF
--- a/graphdb.test.ts
+++ b/graphdb.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest'
+import { GraphDB, Node, Relationship } from './graphdb'
+
+function isNode(x: any): x is Node {
+  return !!x && typeof x.id === 'number' && !!(x as any).properties && !!(x as any).labels
+}
+
+function isRel(x: any): x is Relationship {
+  return x && typeof x.id === 'number' && typeof x.from === 'number' && typeof x.to === 'number'
+}
+
+describe('GraphDB - CREATE', () => {
+  it('creates a single node and returns it', () => {
+    const db = new GraphDB()
+    const res = db.run("CREATE (n:Person {name:'Alice', age:30}) RETURN n")
+    expect(res).toHaveLength(1)
+    expect(isNode(res[0].n)).toBe(true)
+    const n = res[0].n as Node
+    expect(n.properties.name).toBe('Alice')
+    expect(n.properties.age).toBe(30)
+    expect(n.labels.has('Person')).toBe(true)
+  })
+
+  it('creates multiple nodes in one statement', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'}), (b:Person {name:'B'})")
+    expect(db.getAllNodes()).toHaveLength(2)
+  })
+
+  it('creates a relationship with inline endpoints', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'})-[:KNOWS {since:2020}]->(b:Person {name:'B'})")
+    expect(db.getAllNodes()).toHaveLength(2)
+    expect(db.getAllRelationships()).toHaveLength(1)
+    const rel = db.getAllRelationships()[0]
+    expect(rel.type).toBe('KNOWS')
+    expect(rel.properties.since).toBe(2020)
+  })
+})
+
+describe('GraphDB - MATCH nodes', () => {
+  it('matches all nodes and counts them', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'}), (b:Person {name:'B'}), (c:Animal {name:'C'})")
+    const res = db.run('MATCH (n) RETURN count(*) AS cnt')
+    expect(res).toEqual([{ cnt: 3 }])
+  })
+
+  it('matches by label', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'}), (b:Person {name:'B'}), (c:Animal {name:'C'})")
+    const res = db.run('MATCH (p:Person) RETURN count(*) AS c')
+    expect(res).toEqual([{ c: 2 }])
+  })
+
+  it('matches by inline properties', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A', age:40}), (b:Person {name:'B', age:20})")
+    const res = db.run("MATCH (p:Person {age:20}) RETURN p")
+    expect(res).toHaveLength(1)
+    expect((res[0].p as Node).properties.name).toBe('B')
+  })
+})
+
+describe('GraphDB - MATCH relationships', () => {
+  it('returns endpoints and relationship with type filter', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'})-[:KNOWS {since:2020}]->(b:Person {name:'B'})")
+    const res = db.run('MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a, r, b')
+    expect(res).toHaveLength(1)
+    const row = res[0]
+    expect(isNode(row.a)).toBe(true)
+    expect(isRel(row.r)).toBe(true)
+    expect(isNode(row.b)).toBe(true)
+    expect((row.a as Node).properties.name).toBe('A')
+    expect((row.b as Node).properties.name).toBe('B')
+    expect((row.r as Relationship).properties.since).toBe(2020)
+  })
+
+  it('filters on relationship properties', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'})-[:KNOWS {since:2020}]->(b:Person {name:'B'}), (a)-[:KNOWS {since:2010}]->(c:Person {name:'C'})")
+    const res = db.run('MATCH (a:Person)-[r:KNOWS]->(b:Person) WHERE r.since >= 2015 RETURN count(*) AS cnt')
+    expect(res).toEqual([{ cnt: 1 }])
+  })
+})
+
+describe('GraphDB - WHERE', () => {
+  it('supports equality and inequality', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'Alice', age:30}), (b:Person {name:'Bob', age:40})")
+    const eq = db.run("MATCH (p:Person) WHERE p.name = 'Alice' RETURN p")
+    expect(eq).toHaveLength(1)
+    const ne = db.run("MATCH (p:Person) WHERE p.name <> 'Alice' RETURN count(*) AS c")
+    expect(ne).toEqual([{ c: 1 }])
+  })
+
+  it('supports numeric comparisons and boolean logic', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A', age:20}), (b:Person {name:'B', age:30}), (c:Person {name:'C', age:40})")
+    const res = db.run('MATCH (p:Person) WHERE (p.age >= 30 AND p.age < 40) OR p.name = "A" RETURN collect(p) AS arr')
+    // Should include A (age 20 by name) and B (30), exclude C (40)
+    expect(Array.isArray(res[0].arr)).toBe(true)
+    const names = (res[0].arr as Node[]).map((n) => n.properties.name).sort()
+    expect(names).toEqual(['A', 'B'])
+  })
+})
+
+describe('GraphDB - RETURN projections', () => {
+  it('returns variables and properties with aliases', () => {
+    const db = new GraphDB()
+    db.run("CREATE (p:Person {name:'Alice', age:30})")
+    const res = db.run('MATCH (p:Person) RETURN p.name AS name, p.age AS age')
+    expect(res).toEqual([{ name: 'Alice', age: 30 }])
+  })
+
+  it('supports count(var) and count(*)', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person), (b:Person), (c:Animal)")
+    const c1 = db.run('MATCH (n) RETURN count(*) AS total')
+    expect(c1).toEqual([{ total: 3 }])
+    const c2 = db.run('MATCH (p:Person) RETURN count(p) AS persons')
+    expect(c2).toEqual([{ persons: 2 }])
+  })
+})
+
+describe('GraphDB - LIMIT', () => {
+  it('limits the number of rows returned', () => {
+    const db = new GraphDB()
+    db.run("CREATE (a:Person {name:'A'}), (b:Person {name:'B'}), (c:Person {name:'C'})")
+    const res = db.run('MATCH (p:Person) RETURN p LIMIT 2')
+    expect(res).toHaveLength(2)
+  })
+})

--- a/graphdb.ts
+++ b/graphdb.ts
@@ -1,0 +1,891 @@
+// Minimal in-memory Graph DB with a small Cypher subset
+// Supported:
+// - CREATE nodes/relationships: CREATE (a:Label {k:1})-[:TYPE {p:2}]->(b:Other)
+// - MATCH patterns: node-only or single hop relationships
+// - Labels and inline property filters in patterns
+// - WHERE with =, !=, <, <=, >, >= and AND/OR/NOT
+// - RETURN projections: variables, variable.property, count(*), count(var), collect(var)
+// - Aliasing via AS
+// - LIMIT
+
+export type Properties = Record<string, any>
+
+export type Node = {
+  id: number
+  labels: Set<string>
+  properties: Properties
+}
+
+export type Relationship = {
+  id: number
+  type: string
+  from: number
+  to: number
+  properties: Properties
+}
+
+type Binding = Record<string, any>
+
+export class GraphDB {
+  private nodes: Node[] = []
+  private rels: Relationship[] = []
+  private nextNodeId = 1
+  private nextRelId = 1
+
+  // Execute one or more Cypher statements separated by ';'
+  run(cypher: string): any[] {
+    const statements = this.splitStatements(cypher)
+    let lastResult: any[] = []
+    for (const stmt of statements) {
+      if (!stmt.trim()) continue
+      const parser = new Parser(stmt)
+      const ast = parser.parseStatement()
+      lastResult = this.execute(ast)
+    }
+    return lastResult
+  }
+
+  getAllNodes(): Node[] {
+    return this.nodes.slice()
+  }
+
+  getAllRelationships(): Relationship[] {
+    return this.rels.slice()
+  }
+
+  private splitStatements(input: string): string[] {
+    // Split on semicolons that are not inside quotes
+    const out: string[] = []
+    let current = ''
+    let inSingle = false
+    let inDouble = false
+    for (let i = 0; i < input.length; i++) {
+      const ch = input[i]
+      if (ch === "'" && !inDouble) inSingle = !inSingle
+      if (ch === '"' && !inSingle) inDouble = !inDouble
+      if (ch === ';' && !inSingle && !inDouble) {
+        out.push(current)
+        current = ''
+      } else {
+        current += ch
+      }
+    }
+    if (current.trim()) out.push(current)
+    return out
+  }
+
+  private execute(ast: Statement): any[] {
+    switch (ast.kind) {
+      case 'Create': {
+        const scope: Record<string, Node | Relationship> = {}
+        for (const pattern of ast.patterns) {
+          this.instantiatePattern(pattern, scope)
+        }
+        if (ast.returnClause) {
+          const bindings: Binding[] = [scope]
+          let rows = this.applyWhere(bindings, ast.where)
+          rows = this.project(rows, ast.returnClause)
+          if (ast.limit != null) rows = rows.slice(0, ast.limit)
+          return rows
+        }
+        return []
+      }
+      case 'Match': {
+        // Start with a single empty binding
+        let bindings: Binding[] = [{}]
+        for (const pattern of ast.patterns) {
+          bindings = this.matchPattern(pattern, bindings)
+        }
+        bindings = this.applyWhere(bindings, ast.where)
+        let rows = this.project(bindings, ast.returnClause)
+        if (ast.limit != null) rows = rows.slice(0, ast.limit)
+        return rows
+      }
+      default:
+        throw new Error('Unsupported statement')
+    }
+  }
+
+  private instantiatePattern(pattern: Pattern, scope: Record<string, Node | Relationship>): void {
+    if (pattern.kind === 'NodePattern') {
+      const node = this.createNode(pattern.labels, pattern.props)
+      if (pattern.variable) scope[pattern.variable] = node
+      return
+    }
+    if (pattern.kind === 'RelPattern') {
+      // Ensure endpoints exist (create if inline literal pattern specifies labels/props)
+      const left = this.materializeNodeEndpoint(pattern.left, scope)
+      const right = this.materializeNodeEndpoint(pattern.right, scope)
+      const rel = this.createRelationship(left.id, right.id, pattern.relType || '', pattern.relProps)
+      if (pattern.relVar) scope[pattern.relVar] = rel
+      // Bind endpoints if variables present
+      if (pattern.left.variable) scope[pattern.left.variable] = left
+      if (pattern.right.variable) scope[pattern.right.variable] = right
+      return
+    }
+  }
+
+  private materializeNodeEndpoint(nodePat: NodePattern, scope: Record<string, Node | Relationship>): Node {
+    if (nodePat.variable && scope[nodePat.variable] && isNode(scope[nodePat.variable])) {
+      return scope[nodePat.variable] as Node
+    }
+    // Create a new node for CREATE context
+    return this.createNode(nodePat.labels, nodePat.props)
+  }
+
+  private createNode(labels: string[], props: Properties): Node {
+    const node: Node = { id: this.nextNodeId++, labels: new Set(labels), properties: { ...props } }
+    this.nodes.push(node)
+    return node
+  }
+
+  private createRelationship(from: number, to: number, type: string, props: Properties): Relationship {
+    const rel: Relationship = { id: this.nextRelId++, type, from, to, properties: { ...props } }
+    this.rels.push(rel)
+    return rel
+  }
+
+  private matchPattern(pattern: Pattern, inputBindings: Binding[]): Binding[] {
+    if (pattern.kind === 'NodePattern') {
+      const results: Binding[] = []
+      for (const binding of inputBindings) {
+        for (const node of this.nodes) {
+          if (!matchNodeLiteral(node, pattern)) continue
+          if (pattern.variable && binding[pattern.variable] && binding[pattern.variable] !== node) continue
+          const newBinding = { ...binding }
+          if (pattern.variable) newBinding[pattern.variable] = node
+          results.push(newBinding)
+        }
+      }
+      return results
+    } else if (pattern.kind === 'RelPattern') {
+      const results: Binding[] = []
+      for (const binding of inputBindings) {
+        for (const rel of this.rels) {
+          if (pattern.relType && pattern.relType !== rel.type) continue
+          if (!propsMatch(rel.properties, pattern.relProps)) continue
+          const fromNode = this.getNodeById(rel.from)!
+          const toNode = this.getNodeById(rel.to)!
+          if (!matchNodeLiteral(fromNode, pattern.left)) continue
+          if (!matchNodeLiteral(toNode, pattern.right)) continue
+          // Respect existing bindings
+          if (pattern.left.variable && binding[pattern.left.variable] && binding[pattern.left.variable] !== fromNode)
+            continue
+          if (pattern.right.variable && binding[pattern.right.variable] && binding[pattern.right.variable] !== toNode)
+            continue
+          if (pattern.relVar && binding[pattern.relVar] && binding[pattern.relVar] !== rel) continue
+          const newBinding = { ...binding }
+          if (pattern.left.variable) newBinding[pattern.left.variable] = fromNode
+          if (pattern.right.variable) newBinding[pattern.right.variable] = toNode
+          if (pattern.relVar) newBinding[pattern.relVar] = rel
+          results.push(newBinding)
+        }
+      }
+      return results
+    }
+    return inputBindings
+  }
+
+  private getNodeById(id: number): Node | undefined {
+    return this.nodes.find((n) => n.id === id)
+  }
+
+  private applyWhere(bindings: Binding[], where?: Expr): Binding[] {
+    if (!where) return bindings
+    return bindings.filter((b) => truthy(evalExpr(where, b)))
+  }
+
+  private project(bindings: Binding[], ret?: ReturnClause): any[] {
+    if (!ret) return bindings
+    const rows: any[] = []
+    if (ret.items.length === 1 && (ret.items[0] as any).agg) {
+      const item = ret.items[0] as any
+      if (item.agg.func === 'count') {
+        if (item.agg.arg === '*') {
+          const alias = item.alias || 'count'
+          rows.push({ [alias]: bindings.length })
+          return rows
+        } else {
+          const alias = item.alias || 'count'
+          const v = item.agg.arg
+          rows.push({ [alias]: bindings.filter((r) => r[v] != null).length })
+          return rows
+        }
+      }
+      if (item.agg.func === 'collect') {
+        const v = item.agg.of.variable
+        const values = bindings.map((b) => b[v])
+        rows.push({ [item.alias || 'collect']: values })
+        return rows
+      }
+    }
+    for (const b of bindings) {
+      const row: any = {}
+      for (const item of ret.items) {
+        const value = item.agg ? aggregateValue(item, bindings) : resolveProjection(item, b)
+        row[item.alias || itemToKey(item)] = value
+      }
+      rows.push(row)
+    }
+    return rows
+  }
+}
+
+function isNode(x: any): x is Node {
+  return x && typeof x === 'object' && 'labels' in x && 'properties' in x && 'id' in x
+}
+
+function matchNodeLiteral(node: Node, pat: NodePattern): boolean {
+  // Labels
+  for (const lbl of pat.labels) {
+    if (!node.labels.has(lbl)) return false
+  }
+  return propsMatch(node.properties, pat.props)
+}
+
+function propsMatch(obj: Properties, required: Properties): boolean {
+  for (const k of Object.keys(required)) {
+    const v = required[k]
+    if (!deepEquals(obj[k], v)) return false
+  }
+  return true
+}
+
+function deepEquals(a: any, b: any): boolean {
+  if (a === b) return true
+  if (typeof a !== typeof b) return false
+  if (a && b && typeof a === 'object') {
+    const ak = Object.keys(a)
+    const bk = Object.keys(b)
+    if (ak.length !== bk.length) return false
+    for (const k of ak) {
+      if (!deepEquals(a[k], b[k])) return false
+    }
+    return true
+  }
+  return false
+}
+
+function truthy(v: any): boolean {
+  return !!v
+}
+
+// AST definitions
+type Statement =
+  | { kind: 'Create'; patterns: Pattern[]; where?: Expr; returnClause?: ReturnClause; limit?: number }
+  | { kind: 'Match'; patterns: Pattern[]; where?: Expr; returnClause?: ReturnClause; limit?: number }
+
+type Pattern = NodePattern | RelPattern
+
+type NodePattern = {
+  kind: 'NodePattern'
+  variable?: string
+  labels: string[]
+  props: Properties
+}
+
+type RelPattern = {
+  kind: 'RelPattern'
+  left: NodePattern
+  right: NodePattern
+  relVar?: string
+  relType?: string
+  relProps: Properties
+}
+
+type ReturnItem =
+  | { kind: 'Var'; name: string; alias?: string; agg?: undefined }
+  | { kind: 'Prop'; variable: string; property: string; alias?: string; agg?: undefined }
+  | { kind: 'Agg'; agg: { func: 'count'; arg: '*' | string } & { of?: { variable?: string } }; alias?: string }
+  | { kind: 'Agg'; agg: { func: 'collect' } & { of: { variable: string } }; alias?: string }
+
+type ReturnClause = { items: ReturnItem[] }
+
+type Expr =
+  | { kind: 'Binary'; op: 'AND' | 'OR'; left: Expr; right: Expr }
+  | { kind: 'Not'; expr: Expr }
+  | { kind: 'Compare'; op: '=' | '!=' | '<>' | '<' | '<=' | '>' | '>='; left: ValueExpr; right: ValueExpr }
+  | ValueExpr
+
+type ValueExpr =
+  | { kind: 'Literal'; value: any }
+  | { kind: 'PropRef'; variable: string; property: string }
+
+// ----------------- Parser -----------------
+class Parser {
+  private t: Tokenizer
+  constructor(input: string) {
+    this.t = new Tokenizer(input)
+  }
+
+  parseStatement(): Statement {
+    if (this.t.peekIsKw('CREATE')) {
+      this.t.expectKw('CREATE')
+      const patterns = this.parsePatterns()
+      let where: Expr | undefined
+      let ret: ReturnClause | undefined
+      let limit: number | undefined
+      if (this.t.peekIsKw('WHERE')) {
+        this.t.expectKw('WHERE')
+        where = this.parseExpr()
+      }
+      if (this.t.peekIsKw('RETURN')) {
+        ret = this.parseReturn()
+      }
+      if (this.t.peekIsKw('LIMIT')) {
+        this.t.expectKw('LIMIT')
+        limit = this.parseNumber()
+      }
+      this.t.expectEOF()
+      return { kind: 'Create', patterns, where, returnClause: ret, limit }
+    }
+    if (this.t.peekIsKw('MATCH')) {
+      this.t.expectKw('MATCH')
+      const patterns = this.parsePatterns()
+      let where: Expr | undefined
+      let ret: ReturnClause | undefined
+      let limit: number | undefined
+      if (this.t.peekIsKw('WHERE')) {
+        this.t.expectKw('WHERE')
+        where = this.parseExpr()
+      }
+      if (this.t.peekIsKw('RETURN')) {
+        ret = this.parseReturn()
+      }
+      if (this.t.peekIsKw('LIMIT')) {
+        this.t.expectKw('LIMIT')
+        limit = this.parseNumber()
+      }
+      this.t.expectEOF()
+      return { kind: 'Match', patterns, where, returnClause: ret, limit }
+    }
+    throw this.t.error('Expected CREATE or MATCH')
+  }
+
+  private parsePatterns(): Pattern[] {
+    const patterns: Pattern[] = []
+    patterns.push(this.parsePattern())
+    while (this.t.peekSymbol(',')) {
+      this.t.next()
+      patterns.push(this.parsePattern())
+    }
+    return patterns
+  }
+
+  private parsePattern(): Pattern {
+    // Node-only or relationship pattern
+    const left = this.parseNodePattern()
+    if (this.t.peekSymbol('-')) {
+      this.t.expectSymbol('-')
+      this.t.expectSymbol('[')
+      let relVar: string | undefined
+      let relType: string | undefined
+      let relProps: Properties = {}
+      if (this.t.peekIdent()) {
+        // could be var or :TYPE
+        const ident = this.t.readIdent()
+        if (this.t.peekSymbol(':')) {
+          relVar = ident
+          this.t.expectSymbol(':')
+          relType = this.t.readIdent()
+        } else if (ident.toUpperCase() === ident) {
+          // TYPE in all-caps
+          relType = ident
+        } else {
+          relVar = ident
+        }
+      }
+      if (this.t.peekSymbol(':') && !relType) {
+        this.t.expectSymbol(':')
+        relType = this.t.readIdent()
+      }
+      if (this.t.peekSymbol('{')) {
+        relProps = this.parseProps()
+      }
+      this.t.expectSymbol(']')
+      // Support either '-' then '>' or a single '->' token
+      if (this.t.peekSymbol('->')) {
+        this.t.next()
+      } else {
+        this.t.expectSymbol('-')
+        this.t.expectSymbol('>')
+      }
+      const right = this.parseNodePattern()
+      return { kind: 'RelPattern', left, right, relVar, relType, relProps }
+    }
+    return left
+  }
+
+  private parseNodePattern(): NodePattern {
+    this.t.expectSymbol('(')
+    let variable: string | undefined
+    const labels: string[] = []
+    let props: Properties = {}
+    if (this.t.peekIdent()) {
+      variable = this.t.readIdent()
+    }
+    while (this.t.peekSymbol(':')) {
+      this.t.expectSymbol(':')
+      labels.push(this.t.readIdent())
+    }
+    if (this.t.peekSymbol('{')) {
+      props = this.parseProps()
+    }
+    this.t.expectSymbol(')')
+    return { kind: 'NodePattern', variable, labels, props }
+  }
+
+  private parseProps(): Properties {
+    const obj: Properties = {}
+    this.t.expectSymbol('{')
+    if (!this.t.peekSymbol('}')) {
+      while (true) {
+        const key = this.t.readIdent()
+        this.t.expectSymbol(':')
+        obj[key] = this.parseValue()
+        if (this.t.peekSymbol('}')) break
+        this.t.expectSymbol(',')
+      }
+    }
+    this.t.expectSymbol('}')
+    return obj
+  }
+
+  private parseReturn(): ReturnClause {
+    this.t.expectKw('RETURN')
+    const items: ReturnItem[] = []
+    items.push(this.parseReturnItem())
+    while (this.t.peekSymbol(',')) {
+      this.t.next()
+      items.push(this.parseReturnItem())
+    }
+    return { items }
+  }
+
+  private parseReturnItem(): ReturnItem {
+    if (this.t.peekIsKw('COUNT')) {
+      this.t.expectKw('COUNT')
+      this.t.expectSymbol('(')
+      if (this.t.peekSymbol('*')) {
+        this.t.expectSymbol('*')
+        this.t.expectSymbol(')')
+        const alias = this.parseOptionalAlias()
+        return { kind: 'Agg', agg: { func: 'count', arg: '*', of: {} }, alias }
+      } else {
+        const varName = this.t.readIdent()
+        this.t.expectSymbol(')')
+        const alias = this.parseOptionalAlias()
+        return { kind: 'Agg', agg: { func: 'count', arg: varName, of: { variable: varName } }, alias }
+      }
+    }
+    if (this.t.peekIsKw('COLLECT')) {
+      this.t.expectKw('COLLECT')
+      this.t.expectSymbol('(')
+      const varName = this.t.readIdent()
+      this.t.expectSymbol(')')
+      const alias = this.parseOptionalAlias()
+      return { kind: 'Agg', agg: { func: 'collect', of: { variable: varName } }, alias }
+    }
+    const ident = this.t.readIdent()
+    if (this.t.peekSymbol('.')) {
+      this.t.expectSymbol('.')
+      const prop = this.t.readIdent()
+      const alias = this.parseOptionalAlias()
+      return { kind: 'Prop', variable: ident, property: prop, alias }
+    } else {
+      const alias = this.parseOptionalAlias()
+      return { kind: 'Var', name: ident, alias }
+    }
+  }
+
+  private parseOptionalAlias(): string | undefined {
+    if (this.t.peekIsKw('AS')) {
+      this.t.expectKw('AS')
+      return this.t.readIdent()
+    }
+    return undefined
+  }
+
+  private parseExpr(): Expr {
+    return this.parseOr()
+  }
+
+  private parseOr(): Expr {
+    let left = this.parseAnd()
+    while (this.t.peekIsKw('OR')) {
+      this.t.expectKw('OR')
+      const right = this.parseAnd()
+      left = { kind: 'Binary', op: 'OR', left, right }
+    }
+    return left
+  }
+
+  private parseAnd(): Expr {
+    let left = this.parseNot()
+    while (this.t.peekIsKw('AND')) {
+      this.t.expectKw('AND')
+      const right = this.parseNot()
+      left = { kind: 'Binary', op: 'AND', left, right }
+    }
+    return left
+  }
+
+  private parseNot(): Expr {
+    if (this.t.peekIsKw('NOT')) {
+      this.t.expectKw('NOT')
+      return { kind: 'Not', expr: this.parsePrimaryExpr() }
+    }
+    return this.parsePrimaryExpr()
+  }
+
+  private parsePrimaryExpr(): Expr {
+    if (this.t.peekSymbol('(')) {
+      this.t.expectSymbol('(')
+      const e = this.parseExpr()
+      this.t.expectSymbol(')')
+      return e
+    }
+    const left = this.parseValueExpr()
+    if (this.t.peekCompareOp()) {
+      const op = this.t.readCompareOp() as Expr['kind'] extends never ? never : any
+      const right = this.parseValueExpr()
+      return { kind: 'Compare', op, left, right }
+    }
+    return left
+  }
+
+  private parseValueExpr(): ValueExpr {
+    if (this.t.peekString()) {
+      return { kind: 'Literal', value: this.t.readString() }
+    }
+    if (this.t.peekNumber()) {
+      return { kind: 'Literal', value: this.parseNumber() }
+    }
+    // prop ref or bare identifier literal not supported; treat as propref
+    const ident = this.t.readIdent()
+    if (this.t.peekSymbol('.')) {
+      this.t.expectSymbol('.')
+      const prop = this.t.readIdent()
+      return { kind: 'PropRef', variable: ident, property: prop }
+    }
+    // Fallback literal string of identifier
+    return { kind: 'Literal', value: ident }
+  }
+
+  private parseValue(): any {
+    if (this.t.peekString()) return this.t.readString()
+    if (this.t.peekNumber()) return this.parseNumber()
+    if (this.t.peekSymbol('{')) return this.parseProps() // nested object literal
+    if (this.t.peekIsKw('TRUE')) {
+      this.t.expectKw('TRUE')
+      return true
+    }
+    if (this.t.peekIsKw('FALSE')) {
+      this.t.expectKw('FALSE')
+      return false
+    }
+    if (this.t.peekIsKw('NULL')) {
+      this.t.expectKw('NULL')
+      return null
+    }
+    // identifier literal, e.g., enums
+    return this.t.readIdent()
+  }
+
+  private parseNumber(): number {
+    const n = this.t.readNumber()
+    return n
+  }
+}
+
+// ----------------- Tokenizer -----------------
+type Tok =
+  | { type: 'ident'; value: string }
+  | { type: 'number'; value: number }
+  | { type: 'string'; value: string }
+  | { type: 'symbol'; value: string }
+  | { type: 'kw'; value: string }
+  | { type: 'eof' }
+
+class Tokenizer {
+  private i = 0
+  private current?: Tok
+  private tokens: Tok[]
+  constructor(private input: string) {
+    this.tokens = this.lex()
+    this.current = this.tokens[0]
+  }
+
+  private lex(): Tok[] {
+    const t: Tok[] = []
+    const s = this.input
+    const push = (tok: Tok) => t.push(tok)
+    const isAlpha = (c: string) => /[A-Za-z_]/.test(c)
+    const isAlnum = (c: string) => /[A-Za-z0-9_]/.test(c)
+    const symbols = new Set(['(', ')', '[', ']', '{', '}', ',', ':', '.', '-', '>', '<', '=', '!', '*'])
+    let i = 0
+    while (i < s.length) {
+      const ch = s[i]
+      if (ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r') {
+        i++
+        continue
+      }
+      if (ch === '/' && s[i + 1] === '/') {
+        // line comment
+        while (i < s.length && s[i] !== '\n') i++
+        continue
+      }
+      if (ch === '\'' || ch === '"') {
+        const quote = ch
+        i++
+        let str = ''
+        while (i < s.length) {
+          const c = s[i]
+          if (c === '\\') {
+            const next = s[i + 1]
+            const map: Record<string, string> = { n: '\n', r: '\r', t: '\t', '\\': '\\', '"': '"', '\'': '\'' }
+            if (map[next] !== undefined) {
+              str += map[next]
+              i += 2
+              continue
+            }
+          }
+          if (c === quote) {
+            i++
+            break
+          }
+          str += c
+          i++
+        }
+        push({ type: 'string', value: str })
+        continue
+      }
+      if (isAlpha(ch)) {
+        let id = ch
+        i++
+        while (i < s.length && isAlnum(s[i])) {
+          id += s[i]
+          i++
+        }
+        const kw = id.toUpperCase()
+        switch (kw) {
+          case 'CREATE':
+          case 'MATCH':
+          case 'WHERE':
+          case 'RETURN':
+          case 'LIMIT':
+          case 'AND':
+          case 'OR':
+          case 'NOT':
+          case 'COUNT':
+          case 'COLLECT':
+          case 'AS':
+          case 'TRUE':
+          case 'FALSE':
+          case 'NULL':
+            push({ type: 'kw', value: kw })
+            break
+          default:
+            push({ type: 'ident', value: id })
+        }
+        continue
+      }
+      if (/[0-9]/.test(ch)) {
+        let num = ch
+        i++
+        while (i < s.length && /[0-9_]/.test(s[i])) {
+          num += s[i]
+          i++
+        }
+        if (s[i] === '.' && /[0-9]/.test(s[i + 1])) {
+          num += s[i++]
+          while (i < s.length && /[0-9_]/.test(s[i])) {
+            num += s[i]
+            i++
+          }
+        }
+        push({ type: 'number', value: Number(num.replace(/_/g, '')) })
+        continue
+      }
+      if (symbols.has(ch)) {
+        // two-char operators
+        const two = ch + s[i + 1]
+        if (two === '->' || two === '<-' || two === '<=' || two === '>=' || two === '!=' || two === '<>') {
+          push({ type: 'symbol', value: two })
+          i += 2
+          continue
+        }
+        // three-char not needed currently
+        push({ type: 'symbol', value: ch })
+        i++
+        continue
+      }
+      throw new Error(`Unexpected character: ${ch}`)
+    }
+    t.push({ type: 'eof' })
+    return t
+  }
+
+  private idx = 0
+  private tok(): Tok {
+    return this.tokens[this.idx]
+  }
+  private advance() {
+    this.idx++
+  }
+  error(msg: string): Error {
+    return new Error(msg)
+  }
+  next(): Tok {
+    const cur = this.tok()
+    this.advance()
+    return cur
+  }
+  peekSymbol(sym: string): boolean {
+    const t = this.tok()
+    return t.type === 'symbol' && t.value === sym
+  }
+  expectSymbol(sym: string) {
+    const t = this.next()
+    if (t.type !== 'symbol' || t.value !== sym) throw this.error(`Expected symbol '${sym}'`)
+  }
+  peekIdent(): boolean {
+    return this.tok().type === 'ident'
+  }
+  readIdent(): string {
+    const t = this.next()
+    if (t.type !== 'ident') throw this.error('Expected identifier')
+    return t.value
+  }
+  peekIsKw(kw: string): boolean {
+    const t = this.tok()
+    return t.type === 'kw' && t.value === kw
+  }
+  expectKw(kw: string) {
+    const t = this.next()
+    if (t.type !== 'kw' || t.value !== kw) throw this.error(`Expected keyword ${kw}`)
+  }
+  peekString(): boolean {
+    return this.tok().type === 'string'
+  }
+  readString(): string {
+    const t = this.next()
+    if (t.type !== 'string') throw this.error('Expected string')
+    return t.value
+  }
+  peekNumber(): boolean {
+    return this.tok().type === 'number'
+  }
+  readNumber(): number {
+    const t = this.next()
+    if (t.type !== 'number') throw this.error('Expected number')
+    return t.value
+  }
+  peekCompareOp(): boolean {
+    const t = this.tok()
+    return (
+      (t.type === 'symbol' && (t.value === '=' || t.value === '<>' || t.value === '<' || t.value === '<=' || t.value === '>' || t.value === '>=' || t.value === '!='))
+    )
+  }
+  readCompareOp(): string {
+    const t = this.next()
+    if (t.type !== 'symbol') throw this.error('Expected comparison operator')
+    return t.value
+  }
+  expectEOF() {
+    const t = this.tok()
+    if (t.type !== 'eof') throw this.error('Unexpected trailing input')
+  }
+}
+
+// ----------------- Evaluation helpers -----------------
+function resolveProjection(item: ReturnItem, binding: Binding): any {
+  switch (item.kind) {
+    case 'Var':
+      return binding[item.name]
+    case 'Prop': {
+      const obj = binding[item.variable]
+      if (!obj) return undefined
+      return obj.properties?.[item.property]
+    }
+    case 'Agg':
+      throw new Error('Internal error: aggregate should be pre-handled')
+  }
+}
+
+function itemToKey(item: ReturnItem): string {
+  switch (item.kind) {
+    case 'Var':
+      return item.name
+    case 'Prop':
+      return `${item.variable}.${item.property}`
+    case 'Agg':
+      if (item.agg.func === 'count') return 'count'
+      if (item.agg.func === 'collect') return 'collect'
+      return 'agg'
+  }
+}
+
+function aggregateValue(item: ReturnItem, rows: Binding[]): any {
+  if (item.kind !== 'Agg') return undefined
+  if (item.agg.func === 'count') {
+    if (item.agg.arg === '*') return rows.length
+    // count of variable present (non-null)
+    const v = item.agg.arg
+    return rows.filter((r) => r[v] != null).length
+  }
+  if (item.agg.func === 'collect') {
+    // collect variable bindings
+    const v = (item.agg as any).of.variable
+    return rows.map((r) => r[v])
+  }
+}
+
+function evalExpr(expr: Expr, binding: Binding): any {
+  switch (expr.kind) {
+    case 'Literal':
+      return expr.value
+    case 'PropRef': {
+      const v = binding[expr.variable]
+      if (!v) return undefined
+      return v.properties?.[expr.property]
+    }
+    case 'Not':
+      return !truthy(evalExpr(expr.expr, binding))
+    case 'Binary': {
+      const l = truthy(evalExpr(expr.left, binding))
+      if (expr.op === 'AND') return l && truthy(evalExpr(expr.right, binding))
+      if (expr.op === 'OR') return l || truthy(evalExpr(expr.right, binding))
+      return false
+    }
+    case 'Compare': {
+      const l = valueOf(expr.left, binding)
+      const r = valueOf(expr.right, binding)
+      switch (expr.op) {
+        case '=':
+          return deepEquals(l, r)
+        case '!=':
+        case '<>':
+          return !deepEquals(l, r)
+        case '<':
+          return (l as any) < (r as any)
+        case '<=':
+          return (l as any) <= (r as any)
+        case '>':
+          return (l as any) > (r as any)
+        case '>=':
+          return (l as any) >= (r as any)
+        default:
+          return false
+      }
+    }
+  }
+}
+
+function valueOf(v: ValueExpr, binding: Binding): any {
+  if (v.kind === 'Literal') return v.value
+  if (v.kind === 'PropRef') {
+    const obj = binding[v.variable]
+    return obj?.properties?.[v.property]
+  }
+}

--- a/try.ts
+++ b/try.ts
@@ -1,0 +1,8 @@
+import { GraphDB } from './graphdb.ts'
+const db = new GraphDB()
+try {
+  const res = db.run("CREATE (a:Person {name:'A'})-[:KNOWS {since:2020}]->(b:Person {name:'B'})")
+  console.log('RESULT', res)
+} catch (e:any) {
+  console.log('ERROR', e.message)
+}


### PR DESCRIPTION
## Summary
- Introduces a minimal in-memory graph database supporting a subset of Cypher query language
- Supports CREATE and MATCH statements with nodes and relationships
- Implements label and property filtering, WHERE clause with logical and comparison operators
- Supports RETURN projections including variables, properties, count, collect, aliasing, and LIMIT
- Adds comprehensive unit tests covering creation, matching, filtering, and projections
- Provides a simple usage example in `try.ts` demonstrating graph creation and query execution

## Changes

### Core Functionality
- **GraphDB Class**: Implements node and relationship storage with auto-increment IDs
- **Cypher Parsing**: Custom parser for CREATE and MATCH statements with patterns, WHERE, RETURN, and LIMIT
- **Query Execution**: Pattern instantiation for CREATE, pattern matching for MATCH, filtering, projection, and aggregation
- **Expression Evaluation**: Supports boolean logic, comparison operators, and property access

### Testing
- Added `graphdb.test.ts` with extensive tests for:
  - Node and relationship creation
  - Matching nodes and relationships with label and property filters
  - WHERE clause with equality, inequality, numeric comparisons, and boolean logic
  - RETURN clause with variable/property projections, count, collect, aliasing
  - LIMIT clause to restrict result rows

### Example Usage
- Added `try.ts` demonstrating basic graph creation and query execution with error handling

## Test plan
- [x] Run all unit tests in `graphdb.test.ts` to verify correctness of graph operations and query features
- [x] Manual testing of `try.ts` to confirm example runs without errors and outputs expected results

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/733b8fc1-c4e8-479c-9e84-75992e8fd422