### PR TITLE
Implement AST parser chunker using Tree-sitter for multiple languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,15 @@
         "@mcp-ui/server": "^5.2.0",
         "@modelcontextprotocol/inspector": "^0.16.1",
         "@modelcontextprotocol/sdk": "^1.0.3",
-        "axios": "^1.8.4"
+        "axios": "^1.8.4",
+        "tree-sitter": "0.22.4",
+        "tree-sitter-c": "^0.23.1",
+        "tree-sitter-go": "^0.23.1",
+        "tree-sitter-java": "^0.23.1",
+        "tree-sitter-javascript": "^0.23.1",
+        "tree-sitter-python": "^0.23.2",
+        "tree-sitter-ruby": "^0.23.1",
+        "tree-sitter-typescript": "^0.23.2"
       },
       "bin": {
         "ref-tools-mcp": "dist/index.cjs"
@@ -1830,6 +1838,7 @@
       "version": "22.17.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.1.tgz",
       "integrity": "sha512-y3tBaz+rjspDTylNjAX37jEC3TETEFGNJL6uQDxwF9/8GLLIjW1rvVHlynyuUKMnMr1Roq8jOv3vkopBjC4/VA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -3340,6 +3349,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4179,13 +4208,6 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
-      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
@@ -4272,6 +4294,151 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      }
+    },
+    "node_modules/tree-sitter-c": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-c/-/tree-sitter-c-0.23.6.tgz",
+      "integrity": "sha512-0dxXKznVyUA0s6PjNolJNs2yF87O5aL538A/eR6njA5oqX3C3vH4vnx3QdOKwuUdpKEcFdHuiDpRKLLCA/tjvQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-go": {
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/tree-sitter-go/-/tree-sitter-go-0.23.4.tgz",
+      "integrity": "sha512-iQaHEs4yMa/hMo/ZCGqLfG61F0miinULU1fFh+GZreCRtKylFLtvn798ocCZjO2r/ungNZgAY1s1hPFyAwkc7w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.1",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-java": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/tree-sitter-java/-/tree-sitter-java-0.23.5.tgz",
+      "integrity": "sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-javascript": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-javascript/-/tree-sitter-javascript-0.23.1.tgz",
+      "integrity": "sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-python": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.23.6.tgz",
+      "integrity": "sha512-yIM9z0oxKIxT7bAtPOhgoVl6gTXlmlIhue7liFT4oBPF/lha7Ha4dQBS82Av6hMMRZoVnFJI8M6mL+SwWoLD3A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-ruby": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-ruby/-/tree-sitter-ruby-0.23.1.tgz",
+      "integrity": "sha512-d9/RXgWjR6HanN7wTYhS5bpBQLz1VkH048Vm3CodPGyJVnamXMGb8oEhDypVCBq4QnHui9sTXuJBBP3WtCw5RA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.1"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-typescript": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",
+      "integrity": "sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.2.2",
+        "node-gyp-build": "^4.8.2",
+        "tree-sitter-javascript": "^0.23.1"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree-sitter": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-node": {
@@ -4828,6 +4995,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4841,6 +5009,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,15 @@
     "@mcp-ui/server": "^5.2.0",
     "@modelcontextprotocol/inspector": "^0.16.1",
     "@modelcontextprotocol/sdk": "^1.0.3",
-    "axios": "^1.8.4"
+    "axios": "^1.8.4",
+    "tree-sitter": "0.22.4",
+    "tree-sitter-c": "^0.23.1",
+    "tree-sitter-go": "^0.23.1",
+    "tree-sitter-java": "^0.23.1",
+    "tree-sitter-javascript": "^0.23.1",
+    "tree-sitter-python": "^0.23.2",
+    "tree-sitter-ruby": "^0.23.1",
+    "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "module": "index.ts",
   "scripts": {
-    "make-executable": "node -e \"fs.chmodSync('dist/index.cjs', '755');\" --require fs",
-    "build": "esbuild index.ts --outfile=dist/index.cjs --bundle --platform=node --format=cjs --banner:js='#!/usr/bin/env node' && npm run make-executable",
+    "make-executable": "node -e \"fs.chmodSync('dist/index.cjs', '755'); fs.chmodSync('dist/chunker.mjs', '755');\" --require fs",
+    "build": "esbuild index.ts --outfile=dist/index.cjs --bundle --platform=node --format=cjs --banner:js='#!/usr/bin/env node' && esbuild src/cli.ts --outfile=dist/chunker.mjs --bundle --platform=node --format=esm --banner:js='#!/usr/bin/env node' --external:tree-sitter* && npm run make-executable",
     "watch": "esbuild index.ts --outfile=dist/index.cjs --bundle --platform=node --format=cjs --banner:js='#!/usr/bin/env node' --watch",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.cjs",
     "start:http": "TRANSPORT=http node dist/index.cjs",
@@ -17,7 +17,8 @@
     "prepublishOnly": "npm run build"
   },
   "bin": {
-    "ref-tools-mcp": "./dist/index.cjs"
+    "ref-tools-mcp": "./dist/index.cjs",
+    "code-chunker": "./dist/chunker.mjs"
   },
   "files": [
     "dist"

--- a/src/chunker.ts
+++ b/src/chunker.ts
@@ -1,0 +1,270 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import Parser, { SyntaxNode } from 'tree-sitter'
+import JavaScript from 'tree-sitter-javascript'
+import Python from 'tree-sitter-python'
+import Go from 'tree-sitter-go'
+import Java from 'tree-sitter-java'
+import Ruby from 'tree-sitter-ruby'
+import C from 'tree-sitter-c'
+import { typescript, tsx } from 'tree-sitter-typescript'
+
+export type Relation = {
+  type: 'contains' | 'defines' | 'references'
+  targetId: string
+}
+
+export type Chunk = {
+  id: string
+  filePath: string
+  language: string
+  type: string
+  name?: string
+  line: number
+  endLine: number
+  content: string
+  contentHash: string
+  parentId?: string
+  relations: Relation[]
+}
+
+export type ChunkerOptions = {
+  /**
+   * Languages to enable. If omitted, a default set (js,ts,py,go,java,ruby,c) is used.
+   */
+  languages?: string[]
+  /**
+   * A predicate to skip certain paths (e.g., node_modules).
+   */
+  shouldIncludePath?: (absPath: string, relPath: string) => boolean
+}
+
+type LanguageConfig = {
+  name: string
+  exts: string[]
+  language: any
+  /** Node types that constitute a chunk for this language. */
+  chunkNodeTypes: string[]
+  /** Extract a human-friendly name from a chunk node. */
+  getName: (node: SyntaxNode, source: string) => string | undefined
+}
+
+const LANGUAGES: LanguageConfig[] = [
+  {
+    name: 'javascript',
+    exts: ['.js', '.mjs', '.cjs'],
+    language: JavaScript,
+    chunkNodeTypes: ['function_declaration', 'method_definition', 'class_declaration'],
+    getName: nameFromCommonNode,
+  },
+  {
+    name: 'typescript',
+    exts: ['.ts'],
+    language: typescript,
+    chunkNodeTypes: ['function_declaration', 'method_definition', 'class_declaration'],
+    getName: nameFromCommonNode,
+  },
+  {
+    name: 'tsx',
+    exts: ['.tsx'],
+    language: tsx,
+    chunkNodeTypes: ['function_declaration', 'method_definition', 'class_declaration'],
+    getName: nameFromCommonNode,
+  },
+  {
+    name: 'python',
+    exts: ['.py'],
+    language: Python,
+    chunkNodeTypes: ['function_definition', 'class_definition'],
+    getName: (node) => childIdentifier(node),
+  },
+  {
+    name: 'go',
+    exts: ['.go'],
+    language: Go,
+    chunkNodeTypes: ['function_declaration', 'method_declaration', 'type_declaration'],
+    getName: (node, src) => {
+      if (node.type === 'function_declaration' || node.type === 'method_declaration') {
+        const id = node.childForFieldName('name')
+        return id ? textOf(id, src) : undefined
+      }
+      if (node.type === 'type_declaration') {
+        const spec = node.descendantsOfType('type_spec')[0]
+        if (spec) {
+          const id = spec.childForFieldName('name')
+          return id ? textOf(id, src) : undefined
+        }
+      }
+      return undefined
+    },
+  },
+  {
+    name: 'java',
+    exts: ['.java'],
+    language: Java,
+    chunkNodeTypes: ['class_declaration', 'method_declaration', 'interface_declaration'],
+    getName: (node, src) => {
+      const id = node.childForFieldName('name')
+      return id ? textOf(id, src) : undefined
+    },
+  },
+  {
+    name: 'ruby',
+    exts: ['.rb'],
+    language: Ruby,
+    chunkNodeTypes: ['class', 'method'],
+    getName: (node, src) => {
+      const id = node.childForFieldName('name') || node.childForFieldName('method')
+      return id ? textOf(id, src) : undefined
+    },
+  },
+  {
+    name: 'c',
+    exts: ['.c', '.h'],
+    language: C,
+    chunkNodeTypes: ['function_definition'],
+    getName: (node, src) => {
+      // function_definition -> declarator -> function_declarator -> declarator(identifier)
+      const id = node.descendantsOfType('identifier')[0]
+      return id ? textOf(id, src) : undefined
+    },
+  },
+]
+
+function nameFromCommonNode(node: SyntaxNode, src: string): string | undefined {
+  const id =
+    node.childForFieldName('name') ||
+    node.childForFieldName('method') ||
+    node.childForFieldName('identifier') ||
+    node.descendantsOfType('identifier')[0] ||
+    node.descendantsOfType('property_identifier')[0]
+  return id ? textOf(id, src) : undefined
+}
+
+function textOf(node: SyntaxNode, src: string) {
+  return src.slice(node.startIndex, node.endIndex)
+}
+
+function childIdentifier(node: SyntaxNode): string | undefined {
+  const id = node.childForFieldName('name') || node.descendantsOfType('identifier')[0]
+  return id ? id.text : undefined
+}
+
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+function getLanguageForFile(filePath: string, enabled?: string[]): LanguageConfig | undefined {
+  const ext = path.extname(filePath).toLowerCase()
+  return LANGUAGES.find((l) => (!enabled || enabled.includes(l.name)) && l.exts.includes(ext))
+}
+
+function walkDir(root: string, shouldInclude?: (abs: string, rel: string) => boolean): string[] {
+  const out: string[] = []
+  const stack: string[] = ['.']
+  while (stack.length) {
+    const rel = stack.pop()!
+    const abs = path.join(root, rel)
+    const stat = fs.statSync(abs)
+    if (stat.isDirectory()) {
+      for (const ent of fs.readdirSync(abs)) {
+        const childRel = path.join(rel, ent)
+        const childAbs = path.join(root, childRel)
+        if (shouldInclude && !shouldInclude(childAbs, childRel)) continue
+        // Skip common junk by default
+        if (!shouldInclude && /(^|\/)node_modules(\/|$)/.test(childRel)) continue
+        stack.push(childRel)
+      }
+    } else {
+      out.push(abs)
+    }
+  }
+  return out
+}
+
+export async function chunkFile(
+  filePath: string,
+  options: ChunkerOptions = {},
+): Promise<Chunk[] | undefined> {
+  const langCfg = getLanguageForFile(filePath, options.languages)
+  if (!langCfg) return undefined
+  const source = fs.readFileSync(filePath, 'utf8')
+  const parser = new Parser()
+  parser.setLanguage(langCfg.language)
+  const tree = parser.parse(source)
+
+  const chunks: Chunk[] = []
+  const parentStack: { node: SyntaxNode; chunkId: string }[] = []
+
+  const fileId = sha256Hex(`${path.resolve(filePath)}:file`)
+  const fileChunk: Chunk = {
+    id: fileId,
+    filePath: path.resolve(filePath),
+    language: langCfg.name,
+    type: 'file',
+    name: path.basename(filePath),
+    line: 1,
+    endLine: source.split('\n').length,
+    content: source,
+    contentHash: sha256Hex(source),
+    relations: [],
+  }
+  chunks.push(fileChunk)
+  parentStack.push({ node: tree.rootNode, chunkId: fileId })
+
+  const visit = (node: SyntaxNode) => {
+    // If this node is a chunk boundary for this language
+    if (langCfg.chunkNodeTypes.includes(node.type)) {
+      const content = source.slice(node.startIndex, node.endIndex)
+      const id = sha256Hex(`${fileChunk.filePath}:${node.startIndex}:${node.endIndex}`)
+      const parent = parentStack[parentStack.length - 1]
+      const chunk: Chunk = {
+        id,
+        filePath: fileChunk.filePath,
+        language: langCfg.name,
+        type: node.type,
+        name: langCfg.getName(node, source),
+        line: node.startPosition.row + 1,
+        endLine: node.endPosition.row + 1,
+        content,
+        contentHash: sha256Hex(content),
+        parentId: parent?.chunkId,
+        relations: parent ? [{ type: 'contains', targetId: id }] : [],
+      }
+      // Attach relation on parent chunk
+      const parentChunk = chunks.find((c) => c.id === parent?.chunkId)
+      if (parentChunk) parentChunk.relations.push({ type: 'contains', targetId: id })
+      chunks.push(chunk)
+      parentStack.push({ node, chunkId: id })
+    }
+
+    // Recurse
+    for (let i = 0; i < node.namedChildCount; i++) {
+      const child = node.namedChild(i)!
+      visit(child)
+    }
+
+    // Pop if we pushed
+    const top = parentStack[parentStack.length - 1]
+    if (top && top.node === node && top.chunkId !== fileId) {
+      parentStack.pop()
+    }
+  }
+
+  visit(tree.rootNode)
+
+  // If no function/class etc. found, just return the file chunk
+  return chunks
+}
+
+export async function chunkCodebase(rootDir: string, options: ChunkerOptions = {}): Promise<Chunk[]> {
+  const files = walkDir(rootDir, options.shouldIncludePath)
+  const all: Chunk[] = []
+  for (const abs of files) {
+    const res = await chunkFile(abs, options)
+    if (res && res.length) all.push(...res)
+  }
+  return all
+}
+

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { chunkCodebase, type Chunk } from './chunker'
+
+export type CliFormat = 'json' | 'human'
+
+export function toHumanReadable(chunks: Chunk[], opts?: { relativeTo?: string }): string {
+  const rel = (p: string) => (opts?.relativeTo ? path.relative(opts.relativeTo, p) || '.' : p)
+  const lines: string[] = []
+  // Group by file for nicer output
+  const byFile = new Map<string, Chunk[]>()
+  for (const c of chunks) {
+    const key = c.filePath
+    const arr = byFile.get(key) || []
+    arr.push(c)
+    byFile.set(key, arr)
+  }
+  for (const [file, arr] of byFile) {
+    lines.push(`File: ${rel(file)}  (chunks: ${arr.length})`)
+    for (const c of arr) {
+      const name = c.name ? ` ${c.name}` : ''
+      lines.push(`  • [${c.language}] ${c.type}${name} @ ${c.line}-${c.endLine} #${c.id.slice(0,8)}`)
+    }
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
+export function writeJsonChunks(outFile: string, chunks: Chunk[], options?: { format?: 'jsonl' | 'array'; pretty?: boolean }) {
+  const fmt = options?.format ?? 'jsonl'
+  const pretty = options?.pretty ? 2 : undefined
+  if (fmt === 'array') {
+    fs.writeFileSync(outFile, JSON.stringify(chunks, null, pretty))
+  } else {
+    const fd = fs.openSync(outFile, 'w')
+    try {
+      for (const c of chunks) {
+        fs.writeSync(fd, JSON.stringify(c) + '\n')
+      }
+    } finally {
+      fs.closeSync(fd)
+    }
+  }
+}
+
+export function readJsonChunks(inFile: string): Chunk[] {
+  const data = fs.readFileSync(inFile, 'utf8').trim()
+  if (!data) return []
+  const first = data.trimStart()[0]
+  if (first === '[') {
+    return JSON.parse(data) as Chunk[]
+  }
+  const chunks: Chunk[] = []
+  for (const line of data.split(/\r?\n/)) {
+    if (!line.trim()) continue
+    chunks.push(JSON.parse(line))
+  }
+  return chunks
+}
+
+function parseArgs(argv: string[]) {
+  const args: Record<string, string | boolean> = {}
+  const positionals: string[] = []
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith('--')) {
+      const [k, v] = a.split('=')
+      if (typeof v === 'undefined') {
+        const next = argv[i + 1]
+        if (next && !next.startsWith('-')) {
+          args[k.slice(2)] = next
+          i++
+        } else {
+          args[k.slice(2)] = true
+        }
+      } else {
+        args[k.slice(2)] = v
+      }
+    } else {
+      positionals.push(a)
+    }
+  }
+  return { args, positionals }
+}
+
+async function run() {
+  const { args } = parseArgs(process.argv)
+  const root = (args.root as string) || process.cwd()
+  const out = args.out as string
+  const format = ((args.format as string) || 'human') as CliFormat
+  const jsonMode = format === 'json'
+  const jsonArray = !!args.array
+  const pretty = !!args.pretty
+  const languages = (args.languages as string | undefined)?.split(',').map((s) => s.trim())
+
+  const chunks = await chunkCodebase(root, { languages })
+
+  if (!out) {
+    console.error('Missing required --out <file>')
+    process.exit(2)
+  }
+
+  if (jsonMode) {
+    writeJsonChunks(out, chunks, { format: jsonArray ? 'array' : 'jsonl', pretty })
+  } else {
+    const text = toHumanReadable(chunks, { relativeTo: root })
+    fs.writeFileSync(out, text)
+  }
+}
+
+const isDirectRun = import.meta.url === pathToFileURL(process.argv[1]).href
+if (isDirectRun) {
+  run().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}
+
+export default run
+

--- a/test/chunker.test.ts
+++ b/test/chunker.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { chunkCodebase, chunkFile, type Chunk } from '../src/chunker'
+
+function write(dir: string, rel: string, content: string) {
+  const abs = path.join(dir, rel)
+  fs.mkdirSync(path.dirname(abs), { recursive: true })
+  fs.writeFileSync(abs, content)
+}
+
+function findChunk(chunks: Chunk[], predicate: (c: Chunk) => boolean): Chunk {
+  const c = chunks.find(predicate)
+  if (!c) throw new Error('Expected chunk not found')
+  return c
+}
+
+describe('chunker by language', () => {
+  let tmp: string
+  beforeAll(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chunker-'))
+
+    // JavaScript
+    write(
+      tmp,
+      'js/example.js',
+      `export class Greeter {\n  constructor(name) { this.name = name }\n  greet() { return 'hi ' + this.name }\n}\nexport function topLevel(a, b) { return a + b }\n`,
+    )
+
+    // TypeScript
+    write(
+      tmp,
+      'ts/example.ts',
+      `export class Calc {\n  add(a: number, b: number) { return a + b }\n}\nexport function mul(a: number, b: number): number { return a * b }\n`,
+    )
+
+    // Python
+    write(
+      tmp,
+      'py/example.py',
+      `class User:\n    def __init__(self, name):\n        self.name = name\n\n    def hello(self):\n        return 'hi ' + self.name\n\n\ndef util(x, y):\n    return x + y\n`,
+    )
+
+    // Go
+    write(
+      tmp,
+      'go/example.go',
+      `package main\n\ntype Point struct { X int; Y int }\n\nfunc (p Point) Sum() int { return p.X + p.Y }\n\nfunc Top(a int, b int) int { return a + b }\n`,
+    )
+
+    // Java
+    write(
+      tmp,
+      'java/Example.java',
+      `public class Example {\n  public int add(int a, int b) { return a + b; }\n}\n`,
+    )
+
+    // Ruby
+    write(
+      tmp,
+      'rb/example.rb',
+      `class Foo\n  def bar(x, y)\n    x + y\n  end\nend\n`,
+    )
+
+    // C
+    write(
+      tmp,
+      'c/example.c',
+      `#include <stdio.h>\nint add(int a, int b) { return a + b; }\n`,
+    )
+  })
+
+  it('chunks JavaScript with classes and functions', async () => {
+    const file = path.join(tmp, 'js/example.js')
+    const chunks = (await chunkFile(file))!
+    const cls = findChunk(chunks, (c) => c.type === 'class_declaration' && c.name === 'Greeter')
+    const fn = findChunk(chunks, (c) => c.type === 'function_declaration' && c.name === 'topLevel')
+    expect(cls.filePath).toContain('example.js')
+    expect(cls.line).toBeGreaterThan(0)
+    expect(cls.content).toContain('class Greeter')
+    expect(fn.content).toContain('function topLevel')
+    const fileChunk = findChunk(chunks, (c) => c.type === 'file')
+    expect(fileChunk.relations.some((r) => r.type === 'contains' && r.targetId === cls.id)).toBe(true)
+  })
+
+  it('chunks TypeScript with classes and functions', async () => {
+    const file = path.join(tmp, 'ts/example.ts')
+    const chunks = (await chunkFile(file))!
+    const cls = findChunk(chunks, (c) => c.type === 'class_declaration' && c.name === 'Calc')
+    const fn = findChunk(chunks, (c) => c.type === 'function_declaration' && c.name === 'mul')
+    expect(cls.content).toContain('class Calc')
+    expect(fn.content).toContain('function mul')
+  })
+
+  it('chunks Python with classes and functions', async () => {
+    const file = path.join(tmp, 'py/example.py')
+    const chunks = (await chunkFile(file))!
+    const cls = findChunk(chunks, (c) => c.type === 'class_definition' && c.name === 'User')
+    const fn = findChunk(chunks, (c) => c.type === 'function_definition' && c.name === 'util')
+    expect(cls.content).toContain('class User')
+    expect(fn.content).toContain('def util')
+  })
+
+  it('chunks Go with methods and functions', async () => {
+    const file = path.join(tmp, 'go/example.go')
+    const chunks = (await chunkFile(file))!
+    const m = findChunk(chunks, (c) => c.type === 'method_declaration' && c.name === 'Sum')
+    const f = findChunk(chunks, (c) => c.type === 'function_declaration' && c.name === 'Top')
+    expect(m.content).toContain('func (p Point) Sum')
+    expect(f.content).toContain('func Top')
+  })
+
+  it('chunks Java with classes and methods', async () => {
+    const file = path.join(tmp, 'java/Example.java')
+    const chunks = (await chunkFile(file))!
+    const cls = findChunk(chunks, (c) => c.type === 'class_declaration' && c.name === 'Example')
+    const m = findChunk(chunks, (c) => c.type === 'method_declaration' && c.name === 'add')
+    expect(cls.content).toContain('class Example')
+    expect(m.content).toContain('int add')
+  })
+
+  it('chunks Ruby with classes and methods', async () => {
+    const file = path.join(tmp, 'rb/example.rb')
+    const chunks = (await chunkFile(file))!
+    const cls = findChunk(chunks, (c) => c.type === 'class' && c.name === 'Foo')
+    const m = findChunk(chunks, (c) => c.type === 'method' && c.name === 'bar')
+    expect(cls.content).toContain('class Foo')
+    expect(m.content).toContain('def bar')
+  })
+
+  it('chunks C with functions', async () => {
+    const file = path.join(tmp, 'c/example.c')
+    const chunks = (await chunkFile(file))!
+    const fn = findChunk(chunks, (c) => c.type === 'function_definition' && c.name === 'add')
+    expect(fn.content).toContain('int add')
+  })
+
+  it('chunks an entire codebase tree', async () => {
+    const chunks = await chunkCodebase(tmp)
+    // Should have at least one file chunk per file plus some function/class chunks
+    const fileChunks = chunks.filter((c) => c.type === 'file')
+    expect(fileChunks.length).toBeGreaterThanOrEqual(7)
+    // Ensure relationships exist
+    const hasContains = chunks.some((c) => c.relations.some((r) => r.type === 'contains'))
+    expect(hasContains).toBe(true)
+  })
+})
+

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { chunkCodebase } from '../src/chunker'
+import { readJsonChunks, writeJsonChunks, toHumanReadable } from '../src/cli'
+
+function tmpDir(prefix = 'chunker-cli-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+describe('CLI helpers JSON mode', () => {
+  it('writes and reads JSONL correctly', async () => {
+    const dir = tmpDir()
+    const file = path.join(dir, 'sample.js')
+    fs.writeFileSync(
+      file,
+      `// sample
+function add(a, b) { return a + b }
+class Box { constructor(v){ this.v = v } }
+`,
+    )
+
+    const chunks = await chunkCodebase(dir, { languages: ['javascript'] })
+    expect(chunks.length).toBeGreaterThan(0)
+
+    const out = path.join(dir, 'chunks.jsonl')
+    writeJsonChunks(out, chunks) // default jsonl
+    expect(fs.existsSync(out)).toBe(true)
+
+    const back = readJsonChunks(out)
+    expect(back.length).toBe(chunks.length)
+    // spot-check a couple fields
+    expect(back[0]).toHaveProperty('filePath')
+    expect(back[0]).toHaveProperty('contentHash')
+  })
+
+  it('writes and reads JSON array correctly', async () => {
+    const dir = tmpDir()
+    const file = path.join(dir, 'sample.py')
+    fs.writeFileSync(
+      file,
+      `def hi(x):\n    return x\n\nclass C:\n    pass\n`,
+    )
+
+    const chunks = await chunkCodebase(dir, { languages: ['python'] })
+    const out = path.join(dir, 'chunks.json')
+    writeJsonChunks(out, chunks, { format: 'array', pretty: true })
+    const raw = fs.readFileSync(out, 'utf8')
+    expect(raw.trim().startsWith('[')).toBe(true)
+    const back = readJsonChunks(out)
+    expect(back.length).toBe(chunks.length)
+  })
+})
+
+describe('CLI helpers human mode', () => {
+  it('formats human-readable output grouped by file', async () => {
+    const dir = tmpDir()
+    const fileTs = path.join(dir, 't.ts')
+    fs.writeFileSync(fileTs, `export function ping(){ return 'pong' }`)
+
+    const chunks = await chunkCodebase(dir, { languages: ['typescript'] })
+    const text = toHumanReadable(chunks, { relativeTo: dir })
+    expect(text).toMatch(/File: ./)
+    expect(text).toMatch(/\• \[typescript\] /)
+    expect(text.split('\n').length).toBeGreaterThan(1)
+  })
+})
+


### PR DESCRIPTION
## Summary
- Introduces a new chunker module leveraging Tree-sitter to parse source code into AST-based chunks
- Supports multiple programming languages: JavaScript, TypeScript, TSX, Python, Go, Java, Ruby, and C
- Adds functionality to chunk individual files and entire codebases into logical code units (functions, classes, methods, etc.)
- Includes comprehensive tests covering chunking behavior across all supported languages

## Changes

### Core Functionality
- Added `src/chunker.ts` implementing:
  - Language configurations with Tree-sitter parsers and chunk node types
  - Functions to chunk a single file or entire codebase into chunks with relations
  - Chunk data structure capturing file path, language, type, name, line ranges, content, and relations
  - SHA-256 hashing for chunk IDs and content integrity
  - Directory walking with optional path filtering

### Dependencies
- Added Tree-sitter and language-specific parsers (`tree-sitter-javascript`, `tree-sitter-python`, `tree-sitter-go`, `tree-sitter-java`, `tree-sitter-ruby`, `tree-sitter-c`, `tree-sitter-typescript`)
- Added native build dependencies (`node-addon-api`, `node-gyp-build`)

### Tests
- Created `test/chunker.test.ts` with tests for:
  - Chunking JavaScript, TypeScript, Python, Go, Java, Ruby, and C files
  - Verifying chunk types, names, content, and parent-child relations
  - Chunking an entire codebase directory and validating file and code unit chunks

## Test plan
- Run the new chunker tests with Vitest to ensure correct chunk extraction and relations
- Validate chunk IDs and content hashes are consistent
- Confirm support for all specified languages and node types
- Verify directory walking respects path inclusion predicates and excludes `node_modules` by default

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/11c22dd4-4396-4a33-ac9b-1af679cc7e00