### PR TITLE
Add SearchDB with semantic indexing and BM25 search

### DIFF
--- a/searchdb.test.ts
+++ b/searchdb.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { SearchDB, type Embedder, type Labeler, type RelevanceFilter } from './searchdb'
+import type { Chunk } from './chunker'
+
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+function mkChunk(id: string, content: string, filePath = `/tmp/${id}.ts`): Chunk {
+  return {
+    id,
+    filePath,
+    language: 'typescript',
+    type: 'function_declaration',
+    name: id,
+    line: 1,
+    endLine: 1,
+    content,
+    contentHash: sha256Hex(content),
+    relations: [],
+  }
+}
+
+function tmpCacheFile(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'searchdb-'))
+  return path.join(dir, 'cache.json')
+}
+
+// Simple 2-dim embedder: counts of 'alpha' and 'beta'
+const countEmbedder: Embedder = async (text: string) => {
+  const lower = text.toLowerCase()
+  const a = (lower.match(/\balpha\b/g) || []).length
+  const b = (lower.match(/\bbeta\b/g) || []).length
+  return [a, b]
+}
+
+describe('SearchDB', () => {
+  let cachePath: string
+
+  beforeEach(() => {
+    cachePath = tmpCacheFile()
+  })
+
+  it('caches description and embeddings by contentHash', async () => {
+    let labelCalls = 0
+    let embedCalls = 0
+    const labeler: Labeler = async (chunk) => {
+      labelCalls++
+      return `Brief label for ${chunk.name} mentioning foo()`
+    }
+    const embedder: Embedder = async (text) => {
+      embedCalls++
+      return countEmbedder(text)
+    }
+
+    const c = mkChunk('c1', 'alpha content here')
+    const db1 = new SearchDB({ labeler, embedder, cachePath })
+    await db1.addChunk(c)
+    expect(labelCalls).toBe(1)
+    expect(embedCalls).toBe(1)
+    // Ensure cache file written
+    const raw = fs.readFileSync(cachePath, 'utf8')
+    const parsed = JSON.parse(raw)
+    expect(parsed[c.contentHash]).toBeTruthy()
+    expect(Array.isArray(parsed[c.contentHash].embedding)).toBe(true)
+    expect(typeof parsed[c.contentHash].description).toBe('string')
+
+    // New instance should reuse cache and not call label/embed again
+    const db2 = new SearchDB({
+      cachePath,
+      labeler: async () => {
+        throw new Error('labeler should not be called for cached item')
+      },
+      embedder: async () => {
+        throw new Error('embedder should not be called for cached item')
+      },
+    })
+    await db2.addChunk(c)
+  })
+
+  it('BM25 returns token-matching chunks', async () => {
+    const db = new SearchDB({ cachePath, embedder: countEmbedder, labeler: async () => 'desc' })
+    const a = mkChunk('a', 'database connection pool manager')
+    const b = mkChunk('b', 'image processing pipeline for photos')
+    await db.addChunks([a, b])
+    const res = await db.search('connection pool', { bm25K: 2, knnK: 0 })
+    const ids = res.map((c) => c.id)
+    expect(ids).toContain('a')
+  })
+
+  it('KNN returns embedding nearest neighbors', async () => {
+    const db = new SearchDB({ cachePath, embedder: countEmbedder, labeler: async () => 'desc' })
+    const a = mkChunk('a', 'alpha alpha here')
+    const b = mkChunk('b', 'beta beta here')
+    await db.addChunks([a, b])
+    const res = await db.search('alpha', { bm25K: 0, knnK: 1 })
+    expect(res.length).toBe(1)
+    expect(res[0]!.id).toBe('a')
+  })
+
+  it('hybrid merges bm25 and knn candidates', async () => {
+    const db = new SearchDB({ cachePath, embedder: countEmbedder, labeler: async () => 'desc' })
+    const bm25Chunk = mkChunk('t', 'unique textonly tokens zyxwv zyxwv zyxwv')
+    const knnChunk = mkChunk('k', 'alpha alpha content')
+    await db.addChunks([bm25Chunk, knnChunk])
+    const res = await db.search('alpha zyxwv textonly', { bm25K: 1, knnK: 1 })
+    const ids = res.map((c) => c.id)
+    expect(ids).toContain('t')
+    expect(ids).toContain('k')
+  })
+
+  it('final relevance filter applies to descriptions', async () => {
+    const relevanceFilter: RelevanceFilter = async (query, items) => {
+      void query
+      // Keep only items whose description includes 'alpha'
+      const keep = items.filter((i) => /alpha/i.test(i.description)).map((i) => i.id)
+      return keep
+    }
+    const labeler: Labeler = async (chunk) => (chunk.id === 'x' ? 'alpha handler' : 'beta handler')
+    const db = new SearchDB({ cachePath, embedder: countEmbedder, labeler, relevanceFilter })
+    const x = mkChunk('x', 'something')
+    const y = mkChunk('y', 'other')
+    await db.addChunks([x, y])
+    const res = await db.search('alpha query', { bm25K: 2, knnK: 2 })
+    expect(res.map((c) => c.id)).toEqual(['x'])
+  })
+})

--- a/searchdb.ts
+++ b/searchdb.ts
@@ -1,0 +1,282 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import crypto from 'node:crypto'
+import { type Chunk } from './chunker'
+
+export type Embedder = (text: string) => Promise<number[]>
+export type Labeler = (chunk: Chunk) => Promise<string>
+export type RelevanceFilter = (query: string, items: { id: string; description: string }[]) => Promise<string[]>
+
+export type SearchOptions = {
+  knnK?: number
+  bm25K?: number
+}
+
+type CacheEntry = { embedding: number[]; description: string }
+
+function defaultCachePath(): string {
+  const dir = path.join(os.homedir(), '.ref')
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  return path.join(dir, 'search-cache.json')
+}
+
+function readCache(file: string): Record<string, CacheEntry> {
+  try {
+    if (!fs.existsSync(file)) return {}
+    const raw = fs.readFileSync(file, 'utf8')
+    if (!raw.trim()) return {}
+    return JSON.parse(raw)
+  } catch {
+    return {}
+  }
+}
+
+function writeCache(file: string, data: Record<string, CacheEntry>) {
+  const tmp = `${file}.tmp-${process.pid}-${Date.now()}`
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2))
+  fs.renameSync(tmp, file)
+}
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9_]+/g)
+    .filter(Boolean)
+}
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0,
+    na = 0,
+    nb = 0
+  const n = Math.min(a.length, b.length)
+  for (let i = 0; i < n; i++) {
+    const ai = a[i] ?? 0
+    const bi = b[i] ?? 0
+    dot += ai * bi
+    na += ai * ai
+    nb += bi * bi
+  }
+  if (na === 0 || nb === 0) return 0
+  return dot / (Math.sqrt(na) * Math.sqrt(nb))
+}
+
+class BM25Index {
+  private df = new Map<string, number>()
+  private tf = new Map<string, Map<string, number>>() // docId -> term -> tf
+  private docLen = new Map<string, number>()
+  private totalLen = 0
+  private docs = new Set<string>()
+
+  constructor(private k1 = 1.5, private b = 0.75) {}
+
+  add(docId: string, text: string) {
+    const terms = tokenize(text)
+    const len = terms.length
+    const tfMap = new Map<string, number>()
+    for (const t of terms) tfMap.set(t, (tfMap.get(t) || 0) + 1)
+    this.tf.set(docId, tfMap)
+    this.docLen.set(docId, len)
+    this.totalLen += len
+    this.docs.add(docId)
+    // df increments once per doc per term
+    for (const term of new Set(terms)) this.df.set(term, (this.df.get(term) || 0) + 1)
+  }
+
+  remove(docId: string) {
+    const tfMap = this.tf.get(docId)
+    if (!tfMap) return
+    // adjust df
+    for (const term of tfMap.keys()) {
+      const v = (this.df.get(term) || 1) - 1
+      if (v <= 0) this.df.delete(term)
+      else this.df.set(term, v)
+    }
+    const len = this.docLen.get(docId) || 0
+    this.totalLen -= len
+    this.docLen.delete(docId)
+    this.tf.delete(docId)
+    this.docs.delete(docId)
+  }
+
+  score(query: string): Map<string, number> {
+    const qTerms = Array.from(new Set(tokenize(query)))
+    const N = Math.max(1, this.docs.size)
+    const avgdl = this.totalLen > 0 ? this.totalLen / N : 0.0001
+    const scores = new Map<string, number>()
+    for (const [docId, tfMap] of this.tf.entries()) {
+      const dl = this.docLen.get(docId) || 0
+      let s = 0
+      for (const term of qTerms) {
+        const tf = tfMap.get(term) || 0
+        if (tf === 0) continue
+        const df = this.df.get(term) || 0
+        const idf = Math.log(1 + (N - df + 0.5) / (df + 0.5))
+        const denom = tf + this.k1 * (1 - this.b + (this.b * dl) / avgdl)
+        s += idf * ((tf * (this.k1 + 1)) / (denom || 1e-9))
+      }
+      if (s !== 0) scores.set(docId, s)
+    }
+    return scores
+  }
+}
+
+export class SearchDB {
+  private byId = new Map<string, { chunk: Chunk; description: string; embedding: number[] }>()
+  private bm25 = new BM25Index()
+  private cachePath: string
+  private cache: Record<string, CacheEntry>
+
+  constructor(
+    private opts: {
+      embedder?: Embedder
+      labeler?: Labeler
+      relevanceFilter?: RelevanceFilter
+      cachePath?: string
+    } = {},
+  ) {
+    this.cachePath = opts.cachePath || defaultCachePath()
+    this.cache = readCache(this.cachePath)
+  }
+
+  // CRUD
+  getChunk(id: string): Chunk | undefined {
+    return this.byId.get(id)?.chunk
+  }
+
+  listChunks(): Chunk[] {
+    return Array.from(this.byId.values()).map((e) => e.chunk)
+  }
+
+  async addChunk(chunk: Chunk): Promise<void> {
+    const contentHash = chunk.contentHash || sha256Hex(chunk.content)
+    const cached = this.cache[contentHash]
+    let description: string
+    let embedding: number[]
+    if (cached) {
+      description = cached.description
+      embedding = cached.embedding
+    } else {
+      const labeler = this.opts.labeler || defaultLabeler
+      description = await labeler(chunk)
+      const embedder = this.opts.embedder || defaultEmbedder
+      const combined = `${description}\n\n${chunk.content}`
+      embedding = await embedder(combined)
+      this.cache[contentHash] = { description, embedding }
+      writeCache(this.cachePath, this.cache)
+    }
+
+    // Store and update BM25
+    this.byId.set(chunk.id, { chunk, description, embedding })
+    const bm25Text = `${description}\n${chunk.content}`
+    this.bm25.add(chunk.id, bm25Text)
+  }
+
+  async addChunks(chunks: Chunk[]): Promise<void> {
+    for (const c of chunks) await this.addChunk(c)
+  }
+
+  async updateChunk(chunk: Chunk): Promise<void> {
+    this.removeChunk(chunk.id)
+    await this.addChunk(chunk)
+  }
+
+  removeChunk(id: string): void {
+    if (!this.byId.has(id)) return
+    this.byId.delete(id)
+    this.bm25.remove(id)
+  }
+
+  async search(query: string, options: SearchOptions = {}): Promise<Chunk[]> {
+    const knnK = options.knnK ?? 5
+    const bm25K = options.bm25K ?? 5
+
+    // BM25 candidates
+    const bm25Scores = this.bm25.score(query)
+    const bm25Candidates = Array.from(bm25Scores.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, bm25K)
+      .map(([id]) => id)
+
+    // KNN candidates
+    const embedder = this.opts.embedder || defaultEmbedder
+    const qVec = await embedder(query)
+    const knnCandidates = Array.from(this.byId.entries())
+      .map(([id, e]) => ({ id, s: cosine(qVec, e.embedding) }))
+      .sort((a, b) => b.s - a.s)
+      .slice(0, knnK)
+      .map((x) => x.id)
+
+    // Union
+    const uniqueIds = Array.from(new Set([...bm25Candidates, ...knnCandidates]))
+
+    // Final LLM filter on descriptions
+    const items = uniqueIds
+      .map((id) => {
+        const rec = this.byId.get(id)
+        return rec ? { id, description: rec.description } : undefined
+      })
+      .filter((x): x is { id: string; description: string } => !!x)
+    const filter = this.opts.relevanceFilter || defaultRelevanceFilter
+    let keepIds: string[]
+    try {
+      keepIds = await filter(query, items)
+    } catch {
+      keepIds = uniqueIds
+    }
+
+    return keepIds
+      .map((id) => this.byId.get(id)?.chunk)
+      .filter((c): c is Chunk => !!c)
+  }
+}
+
+// -------------- Defaults (networked). Kept simple; tests should stub. --------------
+
+// Very small helper to avoid accidental collisions with missing hash
+function sha256Hex(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex')
+}
+
+async function defaultLabeler(chunk: Chunk): Promise<string> {
+  // Heuristic fallback if network is unavailable; include function name if present
+  const name = chunk.name ? ` ${chunk.name}` : ''
+  const base = `Code${name} in ${path.basename(chunk.filePath)} lines ${chunk.line}-${chunk.endLine}`
+  // Keep description under 30 words
+  return base.split(/\s+/).slice(0, 30).join(' ')
+}
+
+async function defaultEmbedder(text: string): Promise<number[]> {
+  // Simple deterministic embedding: hashing into a fixed-size vector
+  const dim = 64
+  const vec = new Array<number>(dim).fill(0)
+  const tokens = tokenize(text)
+  for (const t of tokens) {
+    const h = crypto.createHash('sha256').update(t).digest()
+    for (let i = 0; i < dim; i++) {
+      const inc = (h[i % h.length] ?? 0) / 255
+      const prev = vec[i] ?? 0
+      vec[i] = prev + inc
+    }
+  }
+  return vec
+}
+
+async function defaultRelevanceFilter(
+  query: string,
+  items: { id: string; description: string }[],
+): Promise<string[]> {
+  const q = new Set(tokenize(query))
+  const out: string[] = []
+  for (const it of items) {
+    const d = new Set(tokenize(it.description))
+    let ok = false
+    for (const term of q) if (d.has(term)) {
+      ok = true
+      break
+    }
+    if (ok) out.push(it.id)
+  }
+  // If nothing matched, return everything to avoid empty results
+  return out.length ? out : items.map((i) => i.id)
+}


### PR DESCRIPTION
## Summary
- Introduces a new `SearchDB` class for semantic code chunk indexing and search
- Supports hybrid search combining BM25 token matching and KNN embedding similarity
- Implements caching of chunk embeddings and descriptions to disk
- Provides customizable embedder, labeler, and relevance filter functions

## Changes

### Core Functionality
- **SearchDB Class**: Manages code chunks with semantic embeddings and textual descriptions
- **BM25Index**: Implements BM25 scoring for token-based search relevance
- **Embedding and Labeling**: Supports pluggable async functions for chunk embedding and labeling
- **Caching**: Persists embeddings and descriptions keyed by content hash to a JSON cache file
- **Search**: Combines BM25 and KNN results, applies final relevance filtering

### Tests
- Added comprehensive tests covering:
  - Caching behavior to avoid redundant embedding/labeling
  - BM25 token matching correctness
  - KNN embedding nearest neighbor search
  - Hybrid search merging BM25 and KNN results
  - Final relevance filtering based on descriptions

## Test plan
- [x] Run all new tests in `searchdb.test.ts` with Vitest
- [x] Verify caching prevents duplicate embedder/labeler calls
- [x] Confirm BM25 and KNN search return expected chunks
- [x] Validate hybrid search returns union of BM25 and KNN results
- [x] Check relevance filter correctly filters search results

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/e07a610a-d8a9-4c32-b4fb-dd8db685c770