### PR TITLE
Refactor graphdb search to return chunks instead of raw rows

### DIFF
--- a/cli_graph.ts
+++ b/cli_graph.ts
@@ -50,9 +50,10 @@ async function run() {
 
   const agent = new SearchAgent(root, { languages })
   await agent.ingest()
-  const rows = agent.search_graph(cypher)
-  for (const [i, r] of rows.entries()) {
-    console.log(`#${i + 1}`, JSON.stringify(r, null, 2))
+  const chunks = agent.search_graph(cypher)
+  for (const [i, c] of chunks.entries()) {
+    const lines = c.type === 'file' ? '' : `:${c.line}-${c.endLine}`
+    console.log(`#${i + 1} ${c.filePath}${lines} ${c.language} ${c.name || ''}`)
   }
 }
 

--- a/cli_search_agent.ts
+++ b/cli_search_agent.ts
@@ -108,10 +108,7 @@ async function run() {
         const params = e.name === 'search_graph' ? e.input?.cypher : e.input?.query
         console.log(`\n→ Tool ${e.name}(${JSON.stringify(params)})`)
       } else if (e.type === 'tool_result') {
-        const summary =
-          e.name === 'search_graph'
-            ? `${(e.output as any[]).length} row(s)`
-            : `${(e.output as any[]).length} chunk(s)`
+        const summary = `${(e.output as any[]).length} chunk(s)`
         console.log(`✓ Result from ${e.name}: ${summary}`)
       } else if (e.type === 'text_delta') {
         process.stdout.write(e.text)
@@ -132,9 +129,9 @@ async function run() {
   s2.stop('Done.')
 
   if (result.kind === 'graph') {
-    // pretty print rows
-    for (const [idx, row] of result.rows.entries()) {
-      console.log(`#${idx + 1}`, JSON.stringify(row, null, 2))
+    for (const c of result.chunks) {
+      const lines = `${c.line}-${c.endLine}`
+      console.log(`• ${path.relative(root, c.filePath)} @ ${lines} (${c.language}) ${c.name || ''}`)
     }
   } else {
     for (const c of result.chunks) {

--- a/search_agent.test.ts
+++ b/search_agent.test.ts
@@ -26,14 +26,14 @@ describe('SearchAgent ingest + search', () => {
 })
 
 describe('SearchAgent graph queries', () => {
-  it('returns nodes via cypher MATCH', async () => {
+  it('returns chunks via cypher MATCH', async () => {
     const dir = tmpDir()
     const f = path.join(dir, 'one.js')
     fs.writeFileSync(f, `function x(){ return 42 }`)
     const agent = new SearchAgent(dir, { languages: ['javascript'] })
     await agent.ingest()
-    const rows = agent.search_graph('MATCH (n:Chunk) RETURN count(*) AS c')
-    expect(rows[0].c).toBeGreaterThan(0)
+    const chunks = agent.search_graph('MATCH (n:Chunk) RETURN n')
+    expect(chunks.length).toBeGreaterThan(0)
   })
 })
 
@@ -64,4 +64,3 @@ describe('SearchAgent watcher + merkle tree', () => {
     expect(all).toContain('watch.ts')
   })
 })
-

--- a/search_agent.ts
+++ b/search_agent.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
 import { chunkCodebase, chunkFile, type Chunk } from './chunker'
-import { GraphDB } from './graphdb'
+import { GraphDB, rowsToChunks } from './graphdb'
 import { SearchDB, type ChunkAnnotator, type RelevanceFilter } from './searchdb'
 // pickChunks is only used via pickChunksFilter when configured
 import { streamText, tool as aiTool } from 'ai'
@@ -20,7 +20,7 @@ export type SearchAgentOptions = {
   agentModel?: string // default: gpt-5
 }
 
-export type QueryResult = { kind: 'graph'; rows: any[] } | { kind: 'search'; chunks: Chunk[] }
+export type QueryResult = { kind: 'graph'; chunks: Chunk[] } | { kind: 'search'; chunks: Chunk[] }
 
 export type AgentMode = 'findContext' | 'answer'
 
@@ -68,8 +68,10 @@ export class SearchAgent {
     return { kind: 'search', chunks }
   }
 
-  search_graph(cypher: string): any[] {
-    return this.graph.run(cypher)
+  search_graph(cypher: string): Chunk[] {
+    const rows = this.graph.run(cypher)
+    const all: Chunk[] = (this.db as any).listChunks()
+    return rowsToChunks(rows, all)
   }
 
   async search_query(prompt: string): Promise<Chunk[]> {
@@ -429,13 +431,15 @@ export async function runAgentWithStreaming(
   const openai = createOpenAI({ apiKey })
   const searchGraph = aiTool({
     description:
-      'Run a Cypher query on the code graph and return rows. Supported (subset): CREATE, MATCH (node-only or single hop), labels (:Label) and inline property filters, WHERE with =, !=, <, <=, >, >= and AND/OR/NOT, RETURN variables and properties, count(*), count(var), collect(var), AS aliases, DISTINCT, ORDER BY, LIMIT. Labels available: Chunk, Code, File. Relationships available: REFERENCES, CONTAINS. Introspection: CALL db.labels().',
+      'Run a Cypher query on the code graph and return matching chunks. Supported (subset): CREATE, MATCH (node-only or single hop), labels (:Label) and inline property filters, WHERE with =, !=, <, <=, >, >= and AND/OR/NOT, RETURN variables and properties, count(*), count(var), collect(var), AS aliases, DISTINCT, ORDER BY, LIMIT. Labels available: Chunk, Code, File. Relationships available: REFERENCES, CONTAINS. Introspection: CALL db.labels().',
     parameters: z.object({ cypher: z.string() }),
     execute: async ({ cypher }) => {
       const rows = self['graph'].run(cypher)
-      return rows.map((row: any) => ({
+      const all: Chunk[] = (self as any)['db'].listChunks()
+      const chunks = rowsToChunks(rows, all)
+      return chunks.map((chunk: Chunk) => ({
         type: 'text',
-        text: JSON.stringify(row),
+        text: `${chunk.filePath} ${chunk.type === 'file' ? '' : `${chunk.line}-${chunk.endLine}`}\n---\n${chunk.content}`,
       }))
     },
   })

--- a/search_agent_references.test.ts
+++ b/search_agent_references.test.ts
@@ -22,10 +22,10 @@ describe('buildCreateCypherForChunks REFERENCES edges', () => {
     const agent = new SearchAgent(dir, { languages: ['typescript'] })
     await agent.ingest()
 
-    const rows = agent.search_graph(
-      "MATCH (u:Chunk { name: 'beta' })-[:REFERENCES]->(d:Chunk { name: 'alpha' }) RETURN count(*) AS count",
+    const chunks = agent.search_graph(
+      "MATCH (u:Chunk { name: 'beta' })-[:REFERENCES]->(d:Chunk { name: 'alpha' }) RETURN u",
     )
-    expect(rows[0]?.count || 0).toBeGreaterThan(0)
+    expect(chunks.length).toBeGreaterThan(0)
   })
 
   it('does not create spurious REFERENCES when a chunk references its own symbol name present in another file', async () => {
@@ -52,12 +52,12 @@ describe('buildCreateCypherForChunks REFERENCES edges', () => {
     await agent.ingest()
 
     // No REFERENCES should exist from any chunk in b.ts to the 'run' definition in a.ts
-    const rows = agent.search_graph(
+    const chunks = agent.search_graph(
       `MATCH (b:Chunk { filePath: '${fb.replace(/\\/g, '\\\\')}' })-[:REFERENCES]->(a:Chunk { name: 'run', filePath: '${fa.replace(
         /\\\\/g,
         '\\\\\\\\',
-      )}' }) RETURN count(*) AS count`,
+      )}' }) RETURN b`,
     )
-    expect(rows[0]?.count || 0).toBe(0)
+    expect(chunks.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- Refactor `search_graph` method in `SearchAgent` to return `Chunk` objects instead of raw database rows
- Introduce `rowsToChunks` helper in `graphdb.ts` to map raw query results to full `Chunk` objects
- Update CLI and tests to handle and display chunks rather than raw rows
- Improve search tool description to clarify it returns chunks

## Changes

### Core Functionality
- Added `rowsToChunks` function in `graphdb.ts` to convert raw graph query results into `Chunk` instances using chunk catalog
- Modified `SearchAgent.search_graph` to use `rowsToChunks` and return `Chunk[]` instead of raw rows
- Updated `QueryResult` type to reflect chunks for graph queries

### CLI Updates
- Changed CLI output in `cli_graph.ts` and `cli_search_agent.ts` to print chunk details (file path, line range, language, name) instead of JSON rows

### Tests
- Updated tests in `search_agent.test.ts` and `search_agent_references.test.ts` to expect chunks instead of raw rows

### Documentation and Tooling
- Updated AI tool description in `search_agent.ts` to indicate it returns matching chunks

## Test plan
- [x] Run existing tests to verify chunk-based graph queries
- [x] Confirm CLI outputs chunk information correctly
- [x] Validate references queries return expected chunks
- [x] Ensure no regressions in search agent ingestion and query behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/ddeda2f8-f801-4731-814a-dc9a867b523a