### PR TITLE
Refactor to expose local code search tools in MCP server

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,12 @@ import { createServer } from 'http'
 import { randomUUID } from 'crypto'
 import { uiHelloTool, callUiHello } from './helloui.js'
 import { generateUiTool, callGenerateUi } from './genui.js'
-import SearchAgent, { createSearchGraphTool, createSearchQueryTool } from './search_agent.js'
+import SearchAgent, {
+  createSearchGraphTool,
+  createSearchQueryTool,
+  SEARCH_GRAPH_DESCRIPTION,
+  SEARCH_QUERY_DESCRIPTION,
+} from './search_agent.js'
 
 // Tool configuration based on client type
 type ToolConfig = {
@@ -124,13 +129,12 @@ function createServerInstance(mcpClient: string = 'unknown', sessionId?: string)
     tools: [
       searchTool,
       readTool,
-      // Conditionally expose local code search tools when configured
-      ...(codeSearchAgent && process.env.REF_DIRECTORY && process.env.OPENAI_API_KEY
+      // Conditionally expose local code search tools when configured (env-gated)
+      ...(process.env.REF_DIRECTORY && process.env.OPENAI_API_KEY
         ? ([
             {
               name: 'search_code_text',
-              description:
-                'Search the configured REF_DIRECTORY codebase for relevant code chunks using natural language.',
+              description: SEARCH_QUERY_DESCRIPTION,
               inputSchema: {
                 type: 'object',
                 properties: { query: { type: 'string', description: 'Natural language query' } },
@@ -139,8 +143,7 @@ function createServerInstance(mcpClient: string = 'unknown', sessionId?: string)
             },
             {
               name: 'search_code_graph',
-              description:
-                'Query the code graph (Cypher subset) over the configured REF_DIRECTORY to return matching chunks.',
+              description: SEARCH_GRAPH_DESCRIPTION,
               inputSchema: {
                 type: 'object',
                 properties: { cypher: { type: 'string', description: 'Cypher query' } },

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import { createServer } from 'http'
 import { randomUUID } from 'crypto'
 import { uiHelloTool, callUiHello } from './helloui.js'
 import { generateUiTool, callGenerateUi } from './genui.js'
+import SearchAgent, { createSearchGraphTool, createSearchQueryTool } from './search_agent.js'
 
 // Tool configuration based on client type
 type ToolConfig = {
@@ -44,6 +45,14 @@ const HTTP_PORT = parseInt(process.env.PORT || '8080', 10)
 
 // Global variables to store current request config
 let currentApiKey: string | undefined = undefined
+// Optional code search agent (gated by env)
+let codeSearchAgent: SearchAgent | undefined
+let codeSearchTools:
+  | {
+      searchQueryExecute: ((args: { query: string }) => Promise<{ type: 'text'; text: string }[]>) | null
+      searchGraphExecute: ((args: { cypher: string }) => Promise<{ type: 'text'; text: string }[]>) | null
+    }
+  | undefined
 
 // Session management for HTTP transport
 const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {}
@@ -112,7 +121,37 @@ function createServerInstance(mcpClient: string = 'unknown', sessionId?: string)
 
   // Register request handlers
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [searchTool, readTool, uiHelloTool, generateUiTool],
+    tools: [
+      searchTool,
+      readTool,
+      // Conditionally expose local code search tools when configured
+      ...(codeSearchAgent && process.env.REF_DIRECTORY && process.env.OPENAI_API_KEY
+        ? ([
+            {
+              name: 'search_code_text',
+              description:
+                'Search the configured REF_DIRECTORY codebase for relevant code chunks using natural language.',
+              inputSchema: {
+                type: 'object',
+                properties: { query: { type: 'string', description: 'Natural language query' } },
+                required: ['query'],
+              },
+            },
+            {
+              name: 'search_code_graph',
+              description:
+                'Query the code graph (Cypher subset) over the configured REF_DIRECTORY to return matching chunks.',
+              inputSchema: {
+                type: 'object',
+                properties: { cypher: { type: 'string', description: 'Cypher query' } },
+                required: ['cypher'],
+              },
+            },
+          ] as any)
+        : ([] as any)),
+      uiHelloTool,
+      generateUiTool,
+    ],
   }))
 
   server.setRequestHandler(ListPromptsRequestSchema, async () => ({
@@ -196,6 +235,44 @@ function createServerInstance(mcpClient: string = 'unknown', sessionId?: string)
         query: string
       }
       return doSearch(input.query, mcpClient, sessionId)
+    }
+
+    if (request.params.name === 'search_code_text') {
+      if (!codeSearchAgent || !codeSearchTools?.searchQueryExecute) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Local code search is not configured. Set REF_DIRECTORY and OPENAI_API_KEY.',
+            },
+          ],
+        }
+      }
+      const input = request.params.arguments as { query: string }
+      if (!input?.query) {
+        throw new McpError(ErrorCode.InvalidParams, 'Missing required argument: query')
+      }
+      const out = await codeSearchTools.searchQueryExecute({ query: input.query })
+      return { content: out }
+    }
+
+    if (request.params.name === 'search_code_graph') {
+      if (!codeSearchAgent || !codeSearchTools?.searchGraphExecute) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'Local code graph search is not configured. Set REF_DIRECTORY and OPENAI_API_KEY.',
+            },
+          ],
+        }
+      }
+      const input = request.params.arguments as { cypher: string }
+      if (!input?.cypher) {
+        throw new McpError(ErrorCode.InvalidParams, 'Missing required argument: cypher')
+      }
+      const out = await codeSearchTools.searchGraphExecute({ cypher: input.cypher })
+      return { content: out }
     }
 
     if (request.params.name === toolConfig.readToolName) {
@@ -576,3 +653,33 @@ export default function () {
   const server = createServerInstance()
   return server
 }
+
+// Initialize local code search agent once per process if env is set
+;(async () => {
+  try {
+    const dir = process.env.REF_DIRECTORY
+    const openai = process.env.OPENAI_API_KEY
+    if (dir && openai) {
+      codeSearchAgent = new SearchAgent(dir, {
+        watch: true,
+        openaiApiKey: openai,
+      })
+      // Kick off initial ingest in background
+      codeSearchAgent.ingest().catch((e) => console.error('SearchAgent ingest error:', e))
+      // Prepare reusable tool executors from ai tools
+      const graphTool = createSearchGraphTool(codeSearchAgent)
+      const queryTool = createSearchQueryTool(codeSearchAgent)
+      codeSearchTools = {
+        searchGraphExecute: graphTool.execute,
+        searchQueryExecute: queryTool.execute,
+      }
+      console.error('Local code SearchAgent initialized for', dir)
+    } else {
+      console.error(
+        'Local code search disabled. Set REF_DIRECTORY and OPENAI_API_KEY to enable search_code_* tools.',
+      )
+    }
+  } catch (e) {
+    console.error('Failed to initialize local code SearchAgent:', e)
+  }
+})()

--- a/search_agent.ts
+++ b/search_agent.ts
@@ -345,6 +345,37 @@ function walkDirSimple(root: string): string[] {
 export default SearchAgent
 
 // -------- Agent Streaming Types and Runner --------
+export function createSearchGraphTool(self: SearchAgent) {
+  return aiTool({
+    description:
+      'Run a Cypher query on the code graph and return matching chunks. Supported (subset): CREATE, MATCH (node-only or single hop), labels (:Label) and inline property filters, WHERE with =, !=, <, <=, >, >= and AND/OR/NOT, RETURN variables and properties, count(*), count(var), collect(var), AS aliases, DISTINCT, ORDER BY, LIMIT. Labels: Chunk, Code, File. Relationships: REFERENCES, CONTAINS. Introspection: CALL db.labels(). Note: chunks are extracted from returned node values. If you return only scalar properties (e.g., d.filePath), the tool will resolve filePath strings to their file chunks; returning node variables (e.g., RETURN d) is still recommended.',
+    parameters: z.object({ cypher: z.string() }),
+    execute: async ({ cypher }) => {
+      const rows = (self as any)['graph'].run(cypher)
+      const all: Chunk[] = (self as any)['db'].listChunks()
+      const chunks = rowsToChunks(rows, all)
+      return chunks.map((chunk: Chunk) => ({
+        type: 'text',
+        text: `${chunk.filePath} ${chunk.type === 'file' ? '' : `${chunk.line}-${chunk.endLine}`}\n---\n${chunk.content}`,
+      }))
+    },
+  })
+}
+
+export function createSearchQueryTool(self: SearchAgent) {
+  return aiTool({
+    description:
+      'Search the codebase for relevant chunks to a natural language query. Should be a full-sentance in natural language describing what you want to find.',
+    parameters: z.object({ query: z.string() }),
+    execute: async ({ query }) => {
+      const chunks = await (self as any)['db'].search(query)
+      return chunks.map((chunk: Chunk) => ({
+        type: 'text',
+        text: `${chunk.filePath} ${chunk.type === 'file' ? '' : `${chunk.line}-${chunk.endLine}`}\n---\n${chunk.content}`,
+      }))
+    },
+  })
+}
 export type AgentStreamEvent =
   | { type: 'status'; message: string }
   | { type: 'text_delta'; text: string }
@@ -428,32 +459,8 @@ export async function runAgentWithStreaming(
   }
 
   const openai = createOpenAI({ apiKey })
-  const searchGraph = aiTool({
-    description:
-      'Run a Cypher query on the code graph and return matching chunks. Supported (subset): CREATE, MATCH (node-only or single hop), labels (:Label) and inline property filters, WHERE with =, !=, <, <=, >, >= and AND/OR/NOT, RETURN variables and properties, count(*), count(var), collect(var), AS aliases, DISTINCT, ORDER BY, LIMIT. Labels: Chunk, Code, File. Relationships: REFERENCES, CONTAINS. Introspection: CALL db.labels(). Note: chunks are extracted from returned node values. If you return only scalar properties (e.g., d.filePath), the tool will resolve filePath strings to their file chunks; returning node variables (e.g., RETURN d) is still recommended.',
-    parameters: z.object({ cypher: z.string() }),
-    execute: async ({ cypher }) => {
-      const rows = self['graph'].run(cypher)
-      const all: Chunk[] = (self as any)['db'].listChunks()
-      const chunks = rowsToChunks(rows, all)
-      return chunks.map((chunk: Chunk) => ({
-        type: 'text',
-        text: `${chunk.filePath} ${chunk.type === 'file' ? '' : `${chunk.line}-${chunk.endLine}`}\n---\n${chunk.content}`,
-      }))
-    },
-  })
-  const searchQuery = aiTool({
-    description:
-      'Search the codebase for relevant chunks to a natural language query. Should be a full-sentance in natural language describing what you want to find.',
-    parameters: z.object({ query: z.string() }),
-    execute: async ({ query }) => {
-      const chunks = await self['db'].search(query)
-      return chunks.map((chunk: Chunk) => ({
-        type: 'text',
-        text: `${chunk.filePath} ${chunk.type === 'file' ? '' : `${chunk.line}-${chunk.endLine}`}\n---\n${chunk.content}`,
-      }))
-    },
-  })
+  const searchGraph = createSearchGraphTool(self)
+  const searchQuery = createSearchQueryTool(self)
 
   // finalize_context tool is only meaningful in findContext mode; it lets the model choose chunk ids
   const finalizeContext = aiTool({


### PR DESCRIPTION
## Summary
- Refactors MCP server to expose local code search tools when configured
- Adds two new tools: `search_code_text` for natural language code search and `search_code_graph` for Cypher graph queries
- Initializes a `SearchAgent` instance if `REF_DIRECTORY` and `OPENAI_API_KEY` environment variables are set
- Provides detailed error messages when local code search is not configured

## Changes

### Server Initialization
- Imports `SearchAgent` and related tool creators
- Adds optional `codeSearchAgent` and `codeSearchTools` global variables
- Initializes `SearchAgent` on startup if environment variables are present
- Starts background ingestion of codebase for search

### MCP Request Handlers
- Conditionally exposes `search_code_text` and `search_code_graph` tools in the tool list
- Implements request handlers for these tools with input validation and error handling

### SearchAgent Module
- Extracts `createSearchGraphTool` and `createSearchQueryTool` functions for reusable AI tools
- Refactors existing inline tool definitions to use these new functions

## Test plan
- [ ] Verify that MCP server exposes new search tools when environment variables are set
- [ ] Test natural language code search via `search_code_text` tool
- [ ] Test Cypher query code graph search via `search_code_graph` tool
- [ ] Confirm appropriate error messages when tools are invoked without configuration
- [ ] Validate background ingestion runs without errors on startup

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/44564e36-b672-43a4-9854-2cf0ad3fae12