### PR TITLE
Fix broken Smithery badge (returns HTTP 500)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Documentation for your agent](header.png)](https://ref.tools)
-[![smithery badge](https://smithery.ai/badge/@ref-tools/ref-tools-mcp)](https://smithery.ai/server/@ref-tools/ref-tools-mcp)
+[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/ai.smithery/ref-tools-ref-tools-mcp.svg)](https://skillselion.com/mcp/tool/ai.smithery/ref-tools-ref-tools-mcp)
 [![Website](https://img.shields.io/badge/Website-ref.tools-blue)](https://ref.tools)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/ref-tools-mcp)](https://www.npmjs.com/package/ref-tools-mcp)


### PR DESCRIPTION
The Smithery badge in the README is serving **HTTP 500**, so it renders as a broken image:

```
https://smithery.ai/badge/@ref-tools/ref-tools-mcp   ->  500
```

This isn't specific to this repo — Smithery's badge endpoint is failing across the ecosystem.

**What this PR does:** removes that one dead badge line, and offers ours in its place.

```markdown
[![Listed on Skillselion](https://skillselion.com/badge/mcp/tool/ai.smithery/ref-tools-ref-tools-mcp.svg)](https://skillselion.com/mcp/tool/ai.smithery/ref-tools-ref-tools-mcp)
```

We'd be happy to have ours sit there instead — Skillselion is an independent directory of agent skills and MCP servers, and this project is already listed at https://skillselion.com/mcp/tool/ai.smithery/ref-tools-ref-tools-mcp whether or not you take the badge.

**Entirely your call, and no hard feelings either way:**
- Happy for the badge to stay → merge as is.
- Prefer the dead badge just gone → say so and I'll amend this to a removal-only change.
- Prefer nothing touched → close it, no reply needed.

Only the dead Smithery image was changed. Any other badges in your README were left untouched.
